### PR TITLE
[parallel] Parallel test execution draft with --lock switch

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -120,11 +120,11 @@ def main():
                     action="store_true",
                     help='List available binaries')
 
-    parser.add_option('', '--lock',
-                    dest='lock_by_target',
-                    default=False,
-                    action="store_true",
-                    help='Use simple resource locking mechanism to run multiple application instances')
+    #parser.add_option('', '--lock',
+    #                dest='lock_by_target',
+    #                default=False,
+    #                action="store_true",
+    #                help='Use simple resource locking mechanism to run multiple application instances')
 
     parser.add_option('', '--digest',
                     dest='digest_source',
@@ -185,7 +185,7 @@ def main():
 
     start = time()
     if opts.lock_by_target:
-        # We are using Greentea proprietary locking meachnism to lock between platforms and targets
+        # We are using Greentea proprietary locking mechanism to lock between platforms and targets
         gt_log("using (experimental) simple locking mechaism")
         gt_log_tab("kettle: %s"% GREENTEA_KETTLE_PATH)
         gt_file_sem, gt_file_sem_name, gt_instance_uuid = greentea_get_app_sem()

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -131,7 +131,6 @@ def main():
 
     parser.add_option('', '--use-tids',
                     dest='use_target_ids',
-                    default=str,
                     help='Specify explicitly which target IDs can be used by Greentea (use comma separated list)')
 
     parser.add_option('', '--digest',
@@ -342,6 +341,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
     test_exec_retcode = 0       # Decrement this value each time test case result is not 'OK'
     test_platforms_match = 0    # Count how many tests were actually ran with current settings
     target_platforms_match = 0  # Count how many platforms were actually tested with current settings
+
     user_target_ids = opts.use_target_ids.split(',') if opts.use_target_ids else []  # User specific target IDs subset to use
 
     # Configuration print only

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -183,7 +183,7 @@ def main():
                     action="store_true",
                     help='Prints package version and exits')
 
-    parser.description = """This automated test script is used to test mbed SDK 3.0 on mbed-enabled devices with support from yotta build tool"""
+    parser.description = """This automated test script is used to execute tests for yotta modules on mbed-enabled devices"""
     parser.epilog = """Example: mbedgt --target frdm-k64f-gcc"""
 
     (opts, args) = parser.parse_args()

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -44,6 +44,7 @@ from mbed_greentea_dlm import GREENTEA_KETTLE_PATH
 from mbed_greentea_dlm import greentea_get_app_sem
 from mbed_greentea_dlm import greentea_update_kettle
 from mbed_greentea_dlm import greentea_clean_kettle
+from mbed_greentea_dlm import greentea_kettle_info
 from mbed_greentea_dlm import greentea_release_target_id
 from mbed_greentea_dlm import greentea_acquire_target_id_from_list
 
@@ -188,9 +189,10 @@ def main():
     start = time()
     if opts.lock_by_target:
         # We are using Greentea proprietary locking mechanism to lock between platforms and targets
+        gt_file_sem, gt_file_sem_name, gt_instance_uuid = greentea_get_app_sem()
         gt_log("using (experimental) simple locking mechanism")
         gt_log_tab("kettle: %s"% GREENTEA_KETTLE_PATH)
-        gt_file_sem, gt_file_sem_name, gt_instance_uuid = greentea_get_app_sem()
+        gt_log_tab("greentea lock uuid: %s)"% gt_instance_uuid)
         with gt_file_sem:
             greentea_update_kettle(gt_instance_uuid)
             try:
@@ -356,6 +358,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
                                         muts_to_test.append(mut)
             else:
                 gt_log("no platform '%s' available to lock (switch --lock)"% unique_platform)
+                print greentea_kettle_info()
     else:
         temp_unique_platforms = set(unique_platforms)
         for mut in mbeds_list:

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -546,11 +546,12 @@ def main_cli(opts, args, gt_instance_uuid=None):
             print exporter_json(test_report)
         else:
             # Final summary
-            gt_log("test report:")
-            text_report, text_results = exporter_text(test_report)
-            print text_report
-            print
-            print "Result: " + text_results
+            if test_report:
+                gt_log("test report:")
+                text_report, text_results = exporter_text(test_report)
+                print text_report
+                print
+                print "Result: " + text_results
 
         # This flag guards 'build only' so we expect only yotta errors
         if test_platforms_match == 0:

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -338,10 +338,6 @@ def main_cli(opts, args, gt_instance_uuid=None):
 
     # Selecting muts to be used for specific platform occurrence
     if opts.lock_by_target:
-        print "unique_platforms", unique_platforms
-        print "platform_to_tid_map", platform_to_tids_map
-        print "opts.lock_by_target:"
-
         temp_unique_platforms = set(unique_platforms)
         for unique_platform in temp_unique_platforms:
             possible_target_ids = platform_to_tids_map[unique_platform]
@@ -359,7 +355,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
                                         target_platforms_match += 1
                                         muts_to_test.append(mut)
             else:
-                gt_log("no platform '%s' available to lock"% unique_platform)
+                gt_log("no platform '%s' available to lock (switch --lock)"% unique_platform)
     else:
         temp_unique_platforms = set(unique_platforms)
         for mut in mbeds_list:

--- a/mbed_greentea/mbed_greentea_dlm.py
+++ b/mbed_greentea/mbed_greentea_dlm.py
@@ -105,7 +105,8 @@ def greentea_acquire_target_id_from_list(possible_target_ids, gt_instance_uuid):
 
         available_target_ids = possible_target_ids
         for locked_tid in already_locked_target_ids:
-            available_target_ids.remove(locked_tid)
+            if locked_tid in available_target_ids:
+                available_target_ids.remove(locked_tid)
 
         if available_target_ids:
             target_id = available_target_ids[0]
@@ -137,3 +138,36 @@ def get_json_data_from_file(json_spec_filename, verbose=False):
     except IOError:
         result = None
     return result
+
+def greentea_kettle_info():
+    """ generates human friendly info about current cettle state
+
+    @details
+    {
+        "475a46d0-41fe-41dc-b5e6-5197a2fcbb28": {
+            "locks": [],
+            "start_time": "2015-10-23 09:29:54",
+            "cwd": "c:\\Work\\mbed-drivers"
+        }
+    }
+    """
+    from prettytable import PrettyTable
+    with greentea_get_global_lock():
+        current_brew = get_json_data_from_file(GREENTEA_KETTLE_PATH)
+        cols = ['greentea_uuid', 'start_time', 'cwd', 'locks']
+        pt = PrettyTable(cols)
+
+        for col in cols:
+            pt.align[col] = "l"
+        pt.padding_width = 1 # One space between column edges and contents (default)
+
+        row = []
+        for greentea_uuid in current_brew:
+            kettle = current_brew[greentea_uuid]
+            row.append(greentea_uuid)
+            row.append(kettle['start_time'])
+            row.append(kettle['cwd'])
+            row.append('\n'.join(kettle['locks']))
+            pt.add_row(row)
+            row = []
+    return pt.get_string()

--- a/mbed_greentea/mbed_greentea_dlm.py
+++ b/mbed_greentea/mbed_greentea_dlm.py
@@ -103,10 +103,8 @@ def greentea_acquire_target_id_from_list(possible_target_ids, gt_instance_uuid):
             locks_list = current_brew[cb]['locks']
             already_locked_target_ids.extend(locks_list)
 
-        available_target_ids = possible_target_ids
-        for locked_tid in already_locked_target_ids:
-            if locked_tid in available_target_ids:
-                available_target_ids.remove(locked_tid)
+        # Remove from possible_target_ids elements from already_locked_target_ids
+        available_target_ids = [item for item in possible_target_ids if item not in already_locked_target_ids]
 
         if available_target_ids:
             target_id = available_target_ids[0]

--- a/mbed_greentea/mbed_greentea_dlm.py
+++ b/mbed_greentea/mbed_greentea_dlm.py
@@ -71,6 +71,8 @@ def greentea_update_kettle(greentea_uuid):
             json.dump(current_brew, kettle_file, indent=4)
 
 def greentea_clean_kettle(greentea_uuid):
+    """ Clean info in local file system config file
+    """
     with greentea_get_global_lock():
         current_brew = get_json_data_from_file(GREENTEA_KETTLE_PATH)
         if not current_brew:
@@ -80,6 +82,8 @@ def greentea_clean_kettle(greentea_uuid):
             json.dump(current_brew, kettle_file, indent=4)
 
 def greentea_acquire_target_id(target_id, gt_instance_uuid):
+    """ Acquire lock on target_id for given greentea UUID
+    """
     with greentea_get_global_lock():
         current_brew = get_json_data_from_file(GREENTEA_KETTLE_PATH)
         if current_brew:
@@ -88,7 +92,8 @@ def greentea_acquire_target_id(target_id, gt_instance_uuid):
                 json.dump(current_brew, kettle_file, indent=4)
 
 def greentea_acquire_target_id_from_list(possible_target_ids, gt_instance_uuid):
-    print "possible_target_ids: ", possible_target_ids
+    """ Acquire lock on target_id from list of possible target_ids for given greentea UUID
+    """
     target_id = None
     already_locked_target_ids = []
     with greentea_get_global_lock():
@@ -98,22 +103,20 @@ def greentea_acquire_target_id_from_list(possible_target_ids, gt_instance_uuid):
             locks_list = current_brew[cb]['locks']
             already_locked_target_ids.extend(locks_list)
 
-        print "already_locked_target_ids: ", already_locked_target_ids
-
         available_target_ids = possible_target_ids
         for locked_tid in already_locked_target_ids:
             available_target_ids.remove(locked_tid)
 
-        print "available_target_ids: ", available_target_ids
         if available_target_ids:
             target_id = available_target_ids[0]
-            print "target_id, gt_instance_uuid:", target_id, gt_instance_uuid
             current_brew[gt_instance_uuid]['locks'].append(target_id)
             with open(GREENTEA_KETTLE_PATH, 'w') as kettle_file:
                 json.dump(current_brew, kettle_file, indent=4)
     return target_id
 
 def greentea_release_target_id(target_id, gt_instance_uuid):
+    """ Release target_id for given greentea UUID
+    """
     with greentea_get_global_lock():
         current_brew = get_json_data_from_file(GREENTEA_KETTLE_PATH)
         if current_brew:


### PR DESCRIPTION
# Description
This is a draft feature to incorporate mbed-device locking mechanism into Greentea.
We are trying to understand how we acquire, release and manage limited resources when executing Greentea.

## Rationale
We want to add parallel execution for testcases to Greentea and we need to figure our APIs and model used so we can extend Greentea with other more professional Distributed Locking Mechanisms and parallel test execution scenarios.

## Features - locking
* ```--lock```switch used to allocate mbed-devices using simple mbed-ls queries and target ID manipulations.

When using ```--lock``` switch you are sure that multiple Greentea instances will not use the same mbed-devices (enumerated with mbed-ls) on the system.

```--lock``` only work in the same user space (synchronisation primitives are stored in the same OS user space), for different OS users we are currently unable to sync locking now.

## Feature - selecting allowed Target IDs
```--use-tids <TARGET_ID_LIST>``` switch used to filter in (only allow) specific Target IDs. User can define list of Target IDs which are allowed in process of testing. List is comma separated.

This option can be used together with ```--lock``` switch.

### Example
We have two ```K64F``` platrforms:
```
$ mbedls
+--------------+---------------------+------------+------------+-------------------------+
|platform_name |platform_name_unique |mount_point |serial_port |target_id                |
+--------------+---------------------+------------+------------+-------------------------+
|K64F          |K64F[0]              |E:          |COM142      |024002011E031E6AE3FDE3D2 |
|K64F          |K64F[1]              |F:          |COM153      |02400203A0811E505D7DE3E8 |
+--------------+---------------------+------------+------------+-------------------------+
```
We want to force Greentea to only use specifi Target ID for testing, for example ```024002011E031E6AE3FDE3D2```. We can use switch ```--use-tids 024002011E031E6AE3FDE3D2``` to predefine available Target IDs.

We will show example with tests from ```mbed-drivers``` repository.
Switch ```-V``` will be used to enable Greentea's verbose mode. Additionally we will use switch ```--skip-build``` to skip building with yotta (we assume building was done already) and switch ```--lock``` to enable locking mechanism. ```--lock``` will optional because we are not planning to run any other concurrent Greentea instance in parallel.
```
$ cd mbed-drivers
$ mbedgt -V -n mbed-drivers-test-basic --skip-build --lock --use-tids 024002011E031E6AE3FDE3D2
```
```
mbedgt: using (experimental) simple locking mechanism
        kettle: C:\Users\przemek\.mbed-greentea\kettle.json
        greentea lock uuid '25e61358-50ad-4060-81ac-d18f26dc9df5'
mbedgt: checking yotta target in current directory
        calling yotta: yotta target
mbedgt: yotta target in current directory is set to 'frdm-k64f-gcc'
mbedgt: detecting connected mbed-enabled devices...
mbedgt: detected 2 devices
        detected 'K64F' -> 'K64F[0]', console at 'COM142', mounted at 'E:', target id '024002011E031E6AE3FDE3D2'
        detected 'K64F' -> 'K64F[1]', console at 'COM153', mounted at 'F:', target id '02400203A0811E505D7DE3E8'
mbedgt: scan available targets for 'K64F' platform...
mbedgt: yotta search for mbed-target 'k64f'
        calling yotta: yotta --plain search -k mbed-target:k64f target
        found target 'frdm-k64f-gcc'
        found target 'frdm-k64f-armcc'
mbedgt: filtering out target ids not on below list (switch --use-tids)
        using only '024002011E031E6AE3FDE3D2'
mbedgt: locking required platforms (switch --lock)
mbedgt: filtering out target ids not on below list (switch --use-tids)
        using only '024002011E031E6AE3FDE3D2'
mbedgt: locking required platform 'K64F'
        available target '024002011E031E6AE3FDE3D2'
        locking platform '024002011E031E6AE3FDE3D2'
        locked 'K64F' -> 'K64F[0]', target_id: '024002011E031E6AE3FDE3D2'
mbedgt: using 'frdm-k64f-gcc' target, prepare to build
mbedgt: skipping calling yotta (specified with --skip-build option)
mbedgt: test case filter: 'mbed-drivers-test-basic' (specified with -n option)
mbedgt: running tests for target 'frdm-k64f-gcc'
        running host test...
mbedgt: selecting test case observer...
        calling mbedhtrun: mbedhtrun -d E: -p COM142 -f ".\build\frdm-k64f-gcc\test\mbed-drivers-test-basic.bin" -C 4 -c shell -m K64F
mbedgt: mbed-host-test-runner: started
MBED: Instrumentation: "COM142" and disk: "E:"
HOST: Copy image onto target...
        1 file(s) copied.
HOST: Initialize serial port...
...port ready!
HOST: Reset target...
HOST: Detecting test case properties...
HOST: Property 'timeout' = '20'
HOST: Property 'host_test_name' = 'default_auto'
HOST: Property 'description' = 'Basic'
HOST: Property 'test_id' = 'MBED_A1'
HOST: Start test...
{{success}}
{{end}}
mbedgt: mbed-host-test-runner: stopped
mbedgt: mbed-host-test-runner: returned 'OK'
        test 'mbed-drivers-test-basic' ......................................................... OK in 1.37 sec
mbedgt: test report:
+---------------+---------------+-------------------------+--------+--------------------+-------------+
| target        | platform_name | test                    | result | elapsed_time (sec) | copy_method |
+---------------+---------------+-------------------------+--------+--------------------+-------------+
| frdm-k64f-gcc | K64F          | mbed-drivers-test-basic | OK     | 1.37               | shell       |
+---------------+---------------+-------------------------+--------+--------------------+-------------+

Result: 1 OK
Completed in 12.59 sec
```
Note: Please note that Greentea will print information related to locking and Target ID filtering:
```
mbedgt: filtering out target ids not on below list (switch --use-tids)
        using only '024002011E031E6AE3FDE3D2'
mbedgt: locking required platforms (switch --lock)
mbedgt: filtering out target ids not on below list (switch --use-tids)
        using only '024002011E031E6AE3FDE3D2'
mbedgt: locking required platform 'K64F'
        available target '024002011E031E6AE3FDE3D2'
        locking platform '024002011E031E6AE3FDE3D2'
        locked 'K64F' -> 'K64F[0]', target_id: '024002011E031E6AE3FDE3D2'
```