### PR TITLE
Experimental, parallel test execution

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -595,10 +595,12 @@ def main_cli(opts, args, gt_instance_uuid=None):
         t.daemon = True
         t.start()
     while test_result_queue.qsize() != len(execute_threads): 
-        sleep(1)
-    # merge partial test reports from diffrent threads to final test report     
+        sleep(1)   
+        
+    # merge partial test reports from diffrent threads to final test report  
     for t in execute_threads:
-        test_return_data = test_result_queue.get()
+        t.join()
+        test_return_data = test_result_queue.get(False)
         test_platforms_match += test_return_data['test_platforms_match']
         test_exec_retcode += test_return_data['test_exec_retcode']
         partial_test_report = test_return_data['test_report']

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -234,7 +234,6 @@ def main():
     return(cli_ret)
 
 def run_test_thread(test_result_queue, test_queue, opts, mut, mut_info, yotta_target_name):
-    global catch_ctrlC_flag
     test_exec_retcode = 0
     test_platforms_match = 0
     test_report = {}

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -597,21 +597,19 @@ def main_cli(opts, args, gt_instance_uuid=None):
         t.start()
     while test_result_queue.qsize() != len(execute_threads): 
         sleep(1)
-         
+    # merge partial test reports from diffrent threads to final test report     
     for t in execute_threads:
         test_return_data = test_result_queue.get()
         test_platforms_match += test_return_data['test_platforms_match']
         test_exec_retcode += test_return_data['test_exec_retcode']
-        temp_test_report = test_return_data['test_report'] #todo: rename temp_ to thread_
+        partial_test_report = test_return_data['test_report']
         # todo: find better solution, maybe use extend
-        try:
-            if temp_test_report.keys()[0] not in test_report:
-                test_report[temp_test_report.keys()[0]] = {}
-                test_report.update(temp_test_report)
+        for report_key in partial_test_report.keys():
+            if report_key not in test_report:
+                test_report[report_key] = {}
+                test_report.update(partial_test_report)
             else:
-                test_report[test_report.keys()[0]].update(temp_test_report[temp_test_report.keys()[0]])
-        except:
-            pass
+                test_report[report_key].update(partial_test_report[report_key])
             
     if opts.verbose_test_configuration_only:
         print

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -595,10 +595,10 @@ def main_cli(opts, args, gt_instance_uuid=None):
     for t in execute_threads:
         t.daemon = True
         t.start()
-    for t in execute_threads: #todo: while len(test_result_queue) != len(execute_threads): sleep()
-        # to catch ctrl c
-        while t.is_alive():
-            sleep(1) # todo: check if get has a timeout and replace while sleep
+    while test_result_queue.qsize() != len(execute_threads): 
+        sleep(1)
+         
+    for t in execute_threads:
         test_return_data = test_result_queue.get()
         test_platforms_match += test_return_data['test_platforms_match']
         test_exec_retcode += test_return_data['test_exec_retcode']

--- a/test/mbed_gt_test_parallel.py
+++ b/test/mbed_gt_test_parallel.py
@@ -1,0 +1,172 @@
+# Copyright 2015 ARM Limited, All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import time
+
+from random import uniform
+from mock import patch
+from mbed_greentea import mbed_greentea_cli
+
+"""
+Mbed greentea parallelisation tests
+"""
+class TestmbedGt(unittest.TestCase):
+    def setUp(self):
+        """
+        Called before test function
+        :return:
+        """
+        pass
+
+    def tearDown(self):
+        """
+        Called after test function
+        :return:
+        """
+        pass
+    
+    @patch('mbed_greentea.mbed_greentea_cli.optparse.OptionParser')
+    @patch('mbed_greentea.mbed_greentea_cli.load_ctest_testsuite')
+    @patch('mbed_greentea.mbed_greentea_cli.mbed_lstools.create')
+    @patch('mbed_greentea.mbed_test_api.Popen')
+    def test_basic(self, popen_mock, mbedLstools_mock, loadCtestTestsuite_mock, optionParser_mock):
+        
+        #runHostTest_mock.side_effect = run_host_test_mock
+        popen_mock.side_effect = PopenMock
+        
+        mbedLstools_mock.side_effect = MbedsMock
+        
+        loadCtestTestsuite_mock.return_value = load_ctest_testsuite_mock()
+        
+        my_gt_opts = GtOptions(list_of_targets="frdm-k64f-gcc", parallel_test_exec=2, report_junit_file_name="junitTestReport", verbose_test_result_only=False)
+        OptionParserMock.static_options = my_gt_opts
+        optionParser_mock.side_effect = OptionParserMock
+        
+        mbed_greentea_cli.main()
+
+ 
+class PopenMock:
+    def __init__(self, *args, **kwargs):
+        self.stdout = StdOutMock()
+        
+    def communicate(self):
+        return "_stdout", "_stderr"
+
+    def returncode(self):
+        return 0
+    
+    def terminate(self):
+        pass 
+        
+class StdOutMock:
+    def __init__(self):
+        self.str =  "MBED: Instrumentation: 'COM11' and disk: 'E:'\nHOST: Copy image onto target...\n\t1 file(s) copied.\nHOST: Initialize serial port...\n...port ready!\nHOST: Reset target...\nHOST: Detecting test case properties...\nHOST: Property 'timeout' = '20'\nHOST: Property 'host_test_name' = 'echo'\nHOST: Property 'description' = 'serial interrupt test'\nHOST: Property 'test_id' = 'MBED_14'\nHOST: Start test...\n...port ready!\nHOST: Starting the ECHO test\n..................................................\n{{success}}\n{{end}}"          
+        self.offset = 0
+        
+    def read(self, size):
+        if self.offset < len(self.str):
+            ret = [self.str[i] for i in range (self.offset, self.offset + size)]
+            self.offset += size
+            return ''.join(ret)
+        else:
+            time.sleep(uniform(0.1, 2))
+            self.offset = 0
+            return None
+
+            
+def run_host_test_mock(*args, **kwargs):
+    random_testduration = uniform(0.1, 2)
+    time.sleep(random_testduration)
+    return ('OK', 'single_test_output', random_testduration, 10)
+ 
+ 
+def load_ctest_testsuite_mock():
+    return {'mbed-drivers-test-echo': '.\\build\\frdm-k64f-gcc\\test\\mbed-drivers-test-echo.bin', 'mbed-drivers-test-time_us': '.\\build\\frdm-k64f-gcc\\test\\mbed-drivers-test-time_us.bin', 
+            'mbed-drivers-test-serial_interrupt': '.\\build\\frdm-k64f-gcc\\test\\mbed-drivers-test-serial_interrupt.bin', 'mbed-drivers-test-blinky': '.\\build\\frdm-k64f-gcc\\test\\mbed-drivers-test-blinky.bin', 
+            'mbed-drivers-test-functionpointer': '.\\build\\frdm-k64f-gcc\\test\\mbed-drivers-test-functionpointer.bin', 'mbed-drivers-test-stdio': '.\\build\\frdm-k64f-gcc\\test\\mbed-drivers-test-stdio.bin', 
+            'mbed-drivers-test-eventhandler': '.\\build\\frdm-k64f-gcc\\test\\mbed-drivers-test-eventhandler.bin', 'mbed-drivers-test-stl': '.\\build\\frdm-k64f-gcc\\test\\mbed-drivers-test-stl.bin', 
+            'mbed-drivers-test-div': '.\\build\\frdm-k64f-gcc\\test\\mbed-drivers-test-div.bin', 'mbed-drivers-test-rtc': '.\\build\\frdm-k64f-gcc\\test\\mbed-drivers-test-rtc.bin', 
+            'mbed-drivers-test-cstring': '.\\build\\frdm-k64f-gcc\\test\\mbed-drivers-test-cstring.bin', 'mbed-drivers-test-cpp': '.\\build\\frdm-k64f-gcc\\test\\mbed-drivers-test-cpp.bin', 
+            'mbed-drivers-test-timeout': '.\\build\\frdm-k64f-gcc\\test\\mbed-drivers-test-timeout.bin', 'mbed-drivers-test-ticker_3': '.\\build\\frdm-k64f-gcc\\test\\mbed-drivers-test-ticker_3.bin', 
+            'mbed-drivers-test-ticker_2': '.\\build\\frdm-k64f-gcc\\test\\mbed-drivers-test-ticker_2.bin', 'mbed-drivers-test-heap_and_stack': '.\\build\\frdm-k64f-gcc\\test\\mbed-drivers-test-heap_and_stack.bin', 
+            'mbed-drivers-test-hello': '.\\build\\frdm-k64f-gcc\\test\\mbed-drivers-test-hello.bin', 'mbed-drivers-test-ticker': '.\\build\\frdm-k64f-gcc\\test\\mbed-drivers-test-ticker.bin', 
+            'mbed-drivers-test-dev_null': '.\\build\\frdm-k64f-gcc\\test\\mbed-drivers-test-dev_null.bin', 'mbed-drivers-test-basic': '.\\build\\frdm-k64f-gcc\\test\\mbed-drivers-test-basic.bin', 
+            'mbed-drivers-test-asynch_spi': '.\\build\\frdm-k64f-gcc\\test\\mbed-drivers-test-asynch_spi.bin', 'mbed-drivers-test-sleep_timeout': '.\\build\\frdm-k64f-gcc\\test\\mbed-drivers-test-sleep_timeout.bin', 
+            'mbed-drivers-test-detect': '.\\build\\frdm-k64f-gcc\\test\\mbed-drivers-test-detect.bin'}
+      
+      
+class GtOptions:
+    def __init__(self, list_of_targets, test_by_names=None, only_build_tests=False, skip_yotta_build=True, copy_method=None, parallel_test_exec=0, 
+                 verbose_test_configuration_only=False, build_to_release=False, build_to_debug=False, list_binaries=False, map_platform_to_yt_target={}, 
+                 use_target_ids=False, lock_by_target=False, digest_source=None, json_test_configuration=None, run_app=None, report_junit_file_name=None, 
+                 report_text_file_name=None, report_json=False, report_fails=False, verbose_test_result_only=False, verbose=True, version=False):
+        
+        self.list_of_targets = list_of_targets
+        self.test_by_names = test_by_names
+        self.only_build_tests = only_build_tests
+        self.skip_yotta_build = skip_yotta_build
+        self.copy_method = copy_method
+        self.parallel_test_exec = parallel_test_exec
+        self.verbose_test_configuration_only = verbose_test_configuration_only
+        self.build_to_release = build_to_release
+        self.build_to_debug = build_to_debug
+        self.list_binaries = list_binaries
+        self.map_platform_to_yt_target = map_platform_to_yt_target
+        self.use_target_ids = use_target_ids
+        self.lock_by_target = lock_by_target
+        self.digest_source = digest_source
+        self.json_test_configuration = json_test_configuration
+        self.run_app = run_app
+        self.report_junit_file_name = report_junit_file_name
+        self.report_text_file_name = report_text_file_name
+        self.report_json = report_json
+        self.report_fails = report_fails
+        self.verbose_test_result_only = verbose_test_result_only
+        self.verbose = verbose
+        self.version = version
+    
+    
+class OptionParserMock:
+    static_options = {}
+    
+    def __init__(self):
+        pass
+        
+    def add_option(self, *args, **kwargs):
+        pass
+        
+    def parse_args(self):
+        return (OptionParserMock.static_options, [])
+      
+      
+class MbedsMock:
+    def __init__(self):
+        pass
+        
+    def list_mbeds(self):
+        return [{'target_id_mbed_htm': '02400203A0811E505D7DE3E8', 'mount_point': 'E:', 'target_id': '02400203A0811E505D7DE3E8', 'serial_port': u'COM11', 'target_id_usb_id': '02400203A0811E505D7DE3E8', 'platform_name': 'K64F'},
+                {'target_id_mbed_htm': '02400203A0811E505D7DE3D9', 'mount_point': 'F:', 'target_id': '02400203A0811E505D7DE3D9', 'serial_port': u'COM12', 'target_id_usb_id': '02400203A0811E505D7DE3D9', 'platform_name': 'K64F'}]
+    
+    def list_mbeds_ext(self):
+        return [{'target_id_mbed_htm': '02400203A0811E505D7DE3E8', 'mount_point': 'E:', 'target_id': '02400203A0811E505D7DE3E8', 'serial_port': u'COM11', 'target_id_usb_id': '02400203A0811E505D7DE3E8', 'platform_name': 'K64F', 'platform_name_unique': 'K64F[0]'},
+                {'target_id_mbed_htm': '02400203A0811E505D7DE3D9', 'mount_point': 'F:', 'target_id': '02400203A0811E505D7DE3D9', 'serial_port': u'COM12', 'target_id_usb_id': '02400203A0811E505D7DE3D9', 'platform_name': 'K64F', 'platform_name_unique': 'K64F[1]'},
+                {'target_id_mbed_htm': '02400203A0811E505D7DE3A7', 'mount_point': 'G:', 'target_id': '02400203A0811E505D7DE3A7', 'serial_port': u'COM13', 'target_id_usb_id': '02400203A0811E505D7DE3A7', 'platform_name': 'K64F', 'platform_name_unique': 'K64F[2]'},
+                {'target_id_mbed_htm': '09400203A0811E505D7DE3B6', 'mount_point': 'H:', 'target_id': '09400203A0811E505D7DE3B6', 'serial_port': u'COM14', 'target_id_usb_id': '09400203A0811E505D7DE3B6', 'platform_name': 'K100F', 'platform_name_unique': 'K100F[0]'}]
+    
+    def list_platforms_ext(self):
+        return {'K64F': 2}
+        
+        
+      

--- a/test/mbed_gt_test_parallel.py
+++ b/test/mbed_gt_test_parallel.py
@@ -41,22 +41,19 @@ class TestmbedGt(unittest.TestCase):
     @patch('mbed_greentea.mbed_greentea_cli.load_ctest_testsuite')
     @patch('mbed_greentea.mbed_greentea_cli.mbed_lstools.create')
     @patch('mbed_greentea.mbed_test_api.Popen')
-    def test_basic(self, popen_mock, mbedLstools_mock, loadCtestTestsuite_mock, optionParser_mock):
-        
+    def test_basic(self, popen_mock, mbedLstools_mock, loadCtestTestsuite_mock, optionParser_mock): 
         #runHostTest_mock.side_effect = run_host_test_mock
         popen_mock.side_effect = PopenMock
-        
         mbedLstools_mock.side_effect = MbedsMock
-        
         loadCtestTestsuite_mock.return_value = load_ctest_testsuite_mock()
         
-        my_gt_opts = GtOptions(list_of_targets="frdm-k64f-gcc", parallel_test_exec=2, report_junit_file_name="junitTestReport", verbose_test_result_only=False)
+        my_gt_opts = GtOptions(list_of_targets="frdm-k64f-gcc", parallel_test_exec=3, test_by_names="mbed-drivers-test-stdio", 
+                               use_target_ids="02400203A0811E505D7DE3D9", report_junit_file_name="junitTestReport")
         OptionParserMock.static_options = my_gt_opts
         optionParser_mock.side_effect = OptionParserMock
         
         mbed_greentea_cli.main()
 
- 
 class PopenMock:
     def __init__(self, *args, **kwargs):
         self.stdout = StdOutMock()


### PR DESCRIPTION
# Description

Added new experimental feature: thread model for running mulitple test jobs in parallel on multiple resources instances (boards) of the same type within greentea, where for each board we have a separate thread.

Currently each unique MUT (mbed under test) is flashed separately one by one, but with this new feature we are able to flash multiple boards at the same time, run test case on hardware and get results in parallel.

Test execution time is reduced by n where n is number of MUTs (MUT: mbed under test).

## Limitations

At the moment the parallelisation is only for resource instances of the **same type**.
Don't use the ```--verbose-test-result``` mode with the new ```--parallel``` mode.

# Usage

To test in parallel use:
```
$ mbedgt -t frdm-k64f-gcc --parallel 2
```
Where ```-t``` specifies the target and ```--parallel``` enables parallel testing with an *int* argument, which specifies the number of boards used in parallel. Logically, it is not possible to test on more devices as connected.

## Example

We have three K64F platforms connected:
```
$ mbedls
+---------------------+----------------------------+-------------------+-------------------+--------------------------------+
|platform_name        |platform_name_unique        |mount_point        |serial_port        |target_id                       |
+---------------------+----------------------------+-------------------+-------------------+--------------------------------+
|K64F                 |K64F[0]                     |E:                 |COM12              |02400201A0B31E095D4DE3B1        |
|K64F                 |K64F[1]                     |G:                 |COM14              |02400201AA3F4E7757C1B3CF        |
|K64F                 |K64F[2]                     |H:                 |COM15              |02400201AA244E7657DAB3CE        |
+---------------------+----------------------------+-------------------+-------------------+--------------------------------+
```
We want to force Greentea to run the tests on 2 boards and divide the test cases, so that we can achieve a speedup of about 2x.

We will show example with tests from mbed-drivers repository. 
```
$ cd mbed-drivers
$ mbedgt -t frdm-k64f-gcc --parallel 2
```
```
mbedgt: detecting connected mbed-enabled devices...
mbedgt: detected 3 devices
        detected 'K64F' -> 'K64F[0]', console at 'COM12', mounted at 'E:', target id '02400201A0B31E095D4DE3B1'
        detected 'K64F' -> 'K64F[1]', console at 'COM14', mounted at 'G:', target id '02400201AA3F4E7757C1B3CF'
        detected 'K64F' -> 'K64F[2]', console at 'COM15', mounted at 'H:', target id '02400201AA244E7657DAB3CE'
mbedgt: yotta search for mbed-target 'k64f'
        calling yotta: yotta --plain search -k mbed-target:k64f target
        found target 'frdm-k64f-gcc'
        found target 'frdm-k64f-armcc'
mbedgt: processing 'frdm-k64f-gcc' yotta target compatible platforms...
mbedgt: processing 'K64F' platform...
mbedgt: using platform 'K64F' for test:
        target_id_mbed_htm = '02400201A0B31E095D4DE3B1'
        mount_point = 'E:'
        target_id = '02400201A0B31E095D4DE3B1'
        serial_port = 'COM12'
        target_id_usb_id = '02400201A0B31E095D4DE3B1'
        platform_name = 'K64F'
        platform_name_unique = 'K64F[0]'
mbedgt: using platform 'K64F' for test:
        target_id_mbed_htm = '02400201AA3F4E7757C1B3CF'
        mount_point = 'G:'
        target_id = '02400201AA3F4E7757C1B3CF'
        serial_port = 'COM14'
        target_id_usb_id = '02400201AA3F4E7757C1B3CF'
        platform_name = 'K64F'
        platform_name_unique = 'K64F[1]'
mbedgt: building your sources and tests with yotta...
        calling yotta: yotta --target=frdm-k64f-gcc,* build
info: generate for target: frdm-k64f-gcc 0.1.3 at C:\Users\stefan.gutmann@arm.com\Documents\GitHub\mbed-drivers\yotta_targets\frdm-k64f-gcc
GCC version is: 4.9.3
-- Configuring done
-- Generating done
-- Build files have been written to: C:/Users/stefan.gutmann@arm.com/Documents/GitHub/mbed-drivers/build/frdm-k64f-gcc
ninja: no work to do.
mbedgt: yotta build for target 'frdm-k64f-gcc' was successful
mbedgt: running 23 tests for target 'frdm-k64f-gcc' and platform 'K64F'
        use 2 instances for parallel testing
mbedgt: test on hardware with target id: 02400201A0B31E095D4DE3B1
        test 'mbed-drivers-test-echo' .......................................................... OK in 6.32 sec
mbedgt: test on hardware with target id: 02400201AA3F4E7757C1B3CF
        test 'mbed-drivers-test-time_us' ....................................................... OK in 11.37 sec
mbedgt: test on hardware with target id: 02400201A0B31E095D4DE3B1
        test 'mbed-drivers-test-serial_interrupt' .............................................. OK in 6.17 sec
mbedgt: test on hardware with target id: 02400201A0B31E095D4DE3B1
        test 'mbed-drivers-test-functionpointer' ............................................... OK in 1.38 sec
mbedgt: test on hardware with target id: 02400201A0B31E095D4DE3B1
        test 'mbed-drivers-test-stdio' ......................................................... OK in 0.74 sec
mbedgt: test on hardware with target id: 02400201AA3F4E7757C1B3CF
        test 'mbed-drivers-test-blinky' ........................................................ TIMEOUT in 20.93 sec
mbedgt: test on hardware with target id: 02400201A0B31E095D4DE3B1
        test 'mbed-drivers-test-eventhandler' .................................................. ERROR in 0.48 sec
mbedgt: test on hardware with target id: 02400201AA3F4E7757C1B3CF
        test 'mbed-drivers-test-stl' ........................................................... OK in 1.37 sec
mbedgt: test on hardware with target id: 02400201A0B31E095D4DE3B1
        test 'mbed-drivers-test-div' ........................................................... OK in 1.38 sec
mbedgt: test on hardware with target id: 02400201A0B31E095D4DE3B1
        test 'mbed-drivers-test-cstring' ....................................................... FAIL in 1.39 sec
mbedgt: test on hardware with target id: 02400201AA3F4E7757C1B3CF
        test 'mbed-drivers-test-rtc' ........................................................... OK in 4.58 sec
mbedgt: test on hardware with target id: 02400201A0B31E095D4DE3B1
        test 'mbed-drivers-test-cpp' ........................................................... OK in 1.39 sec
mbedgt: test on hardware with target id: 02400201AA3F4E7757C1B3CF
        test 'mbed-drivers-test-timeout' ....................................................... OK in 11.52 sec
mbedgt: test on hardware with target id: 02400201A0B31E095D4DE3B1
        test 'mbed-drivers-test-ticker_3' ...................................................... OK in 11.38 sec
mbedgt: test on hardware with target id: 02400201A0B31E095D4DE3B1
        test 'mbed-drivers-test-heap_and_stack' ................................................ OK in 1.38 sec
mbedgt: test on hardware with target id: 02400201AA3F4E7757C1B3CF
        test 'mbed-drivers-test-ticker_2' ...................................................... OK in 11.35 sec
mbedgt: test on hardware with target id: 02400201A0B31E095D4DE3B1
        test 'mbed-drivers-test-hello' ......................................................... OK in 0.38 sec
mbedgt: test on hardware with target id: 02400201A0B31E095D4DE3B1
        test 'mbed-drivers-test-dev_null' ...................................................... OK in 3.47 sec
mbedgt: test on hardware with target id: 02400201AA3F4E7757C1B3CF
        test 'mbed-drivers-test-ticker' ........................................................ OK in 11.37 sec
mbedgt: test on hardware with target id: 02400201A0B31E095D4DE3B1
        test 'mbed-drivers-test-basic' ......................................................... OK in 1.36 sec
mbedgt: test on hardware with target id: 02400201AA3F4E7757C1B3CF
        test 'mbed-drivers-test-asynch_spi' .................................................... ERROR in 0.41 sec
mbedgt: test on hardware with target id: 02400201A0B31E095D4DE3B1
        test 'mbed-drivers-test-sleep_timeout' ................................................. OK in 3.36 sec
mbedgt: test on hardware with target id: 02400201AA3F4E7757C1B3CF
        test 'mbed-drivers-test-detect' ........................................................ FAIL in 0.42 sec
mbedgt: test report:
+---------------+---------------+------------------------------------+---------+--------------------+-------------+
| target        | platform_name | test                               | result  | elapsed_time (sec) | copy_method |
+---------------+---------------+------------------------------------+---------+--------------------+-------------+
| frdm-k64f-gcc | K64F          | mbed-drivers-test-div              | OK      | 1.38               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-rtc              | OK      | 4.58               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-cstring          | FAIL    | 1.39               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-cpp              | OK      | 1.39               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-timeout          | OK      | 11.52              | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-ticker_3         | OK      | 11.38              | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-ticker_2         | OK      | 11.35              | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-heap_and_stack   | OK      | 1.38               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-hello            | OK      | 0.38               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-time_us          | OK      | 11.37              | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-ticker           | OK      | 11.37              | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-echo             | OK      | 6.32               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-serial_interrupt | OK      | 6.17               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-blinky           | TIMEOUT | 20.93              | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-functionpointer  | OK      | 1.38               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-stdio            | OK      | 0.74               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-stl              | OK      | 1.37               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-dev_null         | OK      | 3.47               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-basic            | OK      | 1.36               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-eventhandler     | ERROR   | 0.48               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-asynch_spi       | ERROR   | 0.41               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-sleep_timeout    | OK      | 3.36               | shell       |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-detect           | FAIL    | 0.42               | shell       |
+---------------+---------------+------------------------------------+---------+--------------------+-------------+

Result: 2 FAIL / 18 OK / 1 TIMEOUT / 2 ERROR
completed in 138.94 sec
```