### PR TITLE
Add support for coverage output in test runner output

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -42,6 +42,7 @@ from mbed_greentea.mbed_greentea_dlm import greentea_get_app_sem
 from mbed_greentea.mbed_greentea_dlm import greentea_update_kettle
 from mbed_greentea.mbed_greentea_dlm import greentea_clean_kettle
 from mbed_greentea.mbed_yotta_api import build_with_yotta
+from mbed_greentea.mbed_greentea_hooks import GreenteaHooks
 
 
 try:
@@ -159,6 +160,10 @@ def main():
                     dest='digest_source',
                     help='Redirect input from where test suite should take console input. You can use stdin or file name to get test case console output')
 
+    parser.add_option('-H', '--hooks',
+                    dest='hooks_json',
+                    help='Load hooks used drive extra functionality')
+
     parser.add_option('', '--test-cfg',
                     dest='json_test_configuration',
                     help='Pass to host test data with host test configuration')
@@ -249,7 +254,7 @@ def main():
         print "completed in %.2f sec"% (time() - start)
     return(cli_ret)
 
-def run_test_thread(test_result_queue, test_queue, opts, mut, mut_info, yotta_target_name):
+def run_test_thread(test_result_queue, test_queue, opts, mut, mut_info, yotta_target_name, greentea_hooks):
     test_exec_retcode = 0
     test_platforms_match = 0
     test_report = {}
@@ -287,8 +292,28 @@ def run_test_thread(test_result_queue, test_queue, opts, mut, mut_info, yotta_ta
 
         single_test_result, single_test_output, single_testduration, single_timeout = host_test_result
         test_result = single_test_result
+
+        build_path = os.path.join("./build", yotta_target_name)
+        build_path_abs = os.path.abspath(build_path)
+
         if single_test_result != TEST_RESULT_OK:
             test_exec_retcode += 1
+        else:
+            if greentea_hooks and greentea_hooks.is_hooked_to('hook_test_end'):
+                # Test was successful
+                # We can execute test hook just after test is finished ('hook_test_end')
+                format = {
+                    "test_name": test['test_bin'],
+                    "test_bin_name": os.path.basename(test['image_path']),
+                    "image_path": test['image_path'],
+                    "build_path": build_path,
+                    "build_path_abs": build_path_abs,
+                    "yotta_target_name": yotta_target_name,
+                }
+                gt_log("execute test end hook 'hook_test_end'")
+                for k in format:
+                    gt_log_tab("{%s} -> '%s'"% (k, format[k]))
+                greentea_hooks.run_hook('hook_test_end', format)
 
         # Update report for optional reporting feature
         test_name = test['test_bin'].lower()
@@ -302,6 +327,10 @@ def run_test_thread(test_result_queue, test_queue, opts, mut, mut_info, yotta_ta
         test_report[yotta_target_name][test_name]['elapsed_time'] = single_testduration
         test_report[yotta_target_name][test_name]['platform_name'] = micro
         test_report[yotta_target_name][test_name]['copy_method'] = copy_method
+        test_report[yotta_target_name][test_name]['build_path'] = build_path
+        test_report[yotta_target_name][test_name]['build_path_abs'] = build_path_abs
+        test_report[yotta_target_name][test_name]['image_path'] = test['image_path']
+        test_report[yotta_target_name][test_name]['test_bin_name'] = os.path.basename(test['image_path'])
 
         gt_log("test on hardware with target id: %s \n\ttest '%s' %s %s in %.2f sec"% (mut['target_id'], test['test_bin'], '.' * (80 - len(test['test_bin'])), test_result, single_testduration))
 
@@ -342,6 +371,11 @@ def main_cli(opts, args, gt_instance_uuid=None):
         print_version()
         return (0)
 
+    # We will load hooks from JSON file to support extra behaviour during test execution
+    greentea_hooks = None
+    if opts.hooks_json:
+        greentea_hooks = GreenteaHooks(opts.hooks_json)
+
     # Capture alternative test console inputs, used e.g. in 'yotta test command'
     if opts.digest_source:
         enum_host_tests_path = get_local_host_tests_dir(opts.enum_host_tests)
@@ -350,6 +384,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
                                          port=None,
                                          digest_source=opts.digest_source,
                                          enum_host_tests_path=enum_host_tests_path,
+                                         hooks=greentea_hooks,
                                          verbose=opts.verbose_test_result_only)
 
         single_test_result, single_test_output, single_testduration, single_timeout = host_test_result
@@ -610,10 +645,12 @@ def main_cli(opts, args, gt_instance_uuid=None):
                     # Experimental, parallel test execution
                     #################################################################
                     if number_of_threads < parallel_test_exec:
-                        args = (test_result_queue, test_queue, opts, mut, mut_info, yotta_target_name)
+                        args = (test_result_queue, test_queue, opts, mut, mut_info, yotta_target_name, greentea_hooks)
                         t = Thread(target=run_test_thread, args=args)
                         execute_threads.append(t)
                         number_of_threads += 1
+
+            ####
 
     gt_log_tab("use %s instance%s for testing" % (len(execute_threads), 's' if len(execute_threads) != 1 else ''))
     for t in execute_threads:
@@ -641,6 +678,30 @@ def main_cli(opts, args, gt_instance_uuid=None):
         print
         print "Example: execute 'mbedgt --target=TARGET_NAME' to start testing for TARGET_NAME target"
         return (0)
+
+    gt_log("all tests finished!")
+
+    # We will execute post test hooks on tests
+    for yotta_target in test_report:
+        for test_name in test_report[yotta_target]:
+            test = test_report[yotta_target][test_name]
+            # Test was successful
+            if test['single_test_result'] == 'OK':
+                if greentea_hooks and greentea_hooks.is_hooked_to('hook_post_test_end'):
+                    # We can execute this test hook just after all tests are finished ('hook_post_test_end')
+                    format = {
+                        "test_name": test_name,
+                        "test_bin_name": test['test_bin_name'],
+                        "image_path": test['image_path'],
+                        "build_path": test['build_path'],
+                        "build_path_abs": test['build_path_abs'],
+                        "yotta_target_name": yotta_target,
+                    }
+                    gt_log("execute post test end hook 'hook_post_test_end'")
+                    for k in format:
+                        gt_log_tab("{%s} -> '%s'"% (k, format[k]))
+                    greentea_hooks.run_hook('hook_post_test_end', format)
+
 
     # This tool is designed to work in CI
     # We want to return success codes based on tool actions,

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -725,6 +725,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
                     }
                     greentea_hooks.run_hook_ext('hook_post_test_end', format)
         if greentea_hooks:
+            # Call hook executed for each yotta target, just after all tests are finished
             build_path = os.path.join("./build", yotta_target)
             build_path_abs = os.path.abspath(build_path)
             # We can execute this test hook just after all tests are finished ('hook_post_test_end')

--- a/mbed_greentea/mbed_greentea_hooks.py
+++ b/mbed_greentea/mbed_greentea_hooks.py
@@ -1,0 +1,90 @@
+"""
+mbed SDK
+Copyright (c) 2011-2015 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Author: Przemyslaw Wirkus <Przemyslaw.wirkus@arm.com>
+"""
+
+import json
+from mbed_greentea.mbed_greentea_log import gt_log
+from mbed_greentea.mbed_greentea_log import gt_bright
+from mbed_greentea.mbed_greentea_log import gt_log_tab
+from mbed_greentea.mbed_greentea_log import gt_log_err
+from mbed_greentea.mbed_test_api import run_cli_command
+
+"""
+List of available hooks:
+* hook_test_end - executed when test is completed
+* hook_all_test_end - executed when all tests are completed
+"""
+
+
+class GreenteaTestHook():
+    """! Class used to define
+    """
+    name = None
+
+    def __init__(self, name, ):
+        pass
+
+    def run(self, format=None):
+        pass
+
+class GreenteaCliTestHook(GreenteaTestHook):
+    """! Class used to define a hook which will call command line program
+    """
+    cmd = None
+
+    def __init__(self, name, cmd):
+        GreenteaTestHook.__init__(self, name)
+        self.cmd = cmd
+
+    def run(self, format=None):
+        """! Runs hook
+        @param format Used to format string with cmd, notation used is e.g: {build_name}
+        """
+        cmd = self.cmd
+        if format:
+            cmd = self.cmd.format(**format)
+
+        return run_cli_command(cmd, shell=False)
+
+class GreenteaHooks():
+    """! Class used to store all hooks
+    @details Hooks command starts with '$' dollar sign
+    """
+    HOOKS = {}
+    def __init__(self, path_to_hooks):
+        """! Opens JSON file with
+        """
+        try:
+            with open(path_to_hooks, 'r') as data_file:
+                hooks = json.load(data_file)
+                if 'hooks' in hooks:
+                    for hook in hooks['hooks']:
+                        hook_name = hook
+                        hook_expression = hooks['hooks'][hook]
+                        # This is a command line hook
+                        if hook_expression.startswith('$'):
+                            self.HOOKS[hook_name] = GreenteaCliTestHook(hook_name, hook_expression[1:])
+        except IOError as e:
+            HOOKS = None
+
+    def is_hooked_to(self, hook_name):
+        return hook_name in self.HOOKS
+
+    def run_hook(self, hook_name, format):
+        if hook_name in self.HOOKS:
+            return self.HOOKS[hook_name].run(format)

--- a/mbed_greentea/mbed_greentea_hooks.py
+++ b/mbed_greentea/mbed_greentea_hooks.py
@@ -20,7 +20,6 @@ Author: Przemyslaw Wirkus <Przemyslaw.wirkus@arm.com>
 import re
 import json
 import subprocess
-from mbed_greentea.mbed_test_api import run_cli_command
 from mbed_greentea.mbed_greentea_log import gt_logger
 
 """
@@ -58,7 +57,7 @@ class GreenteaCliTestHook(GreenteaTestHook):
                 stderr=subprocess.STDOUT,
                 shell=shell)
         except subprocess.CalledProcessError as e:
-            print str(e)
+            gt_logger.gt_log_err(str(e))
             result = False
         return (_stdout, result)
 
@@ -70,7 +69,7 @@ class GreenteaCliTestHook(GreenteaTestHook):
         gt_logger.gt_log("hook '%s' execution"% self.name)
         cmd = self.format_before_run(self.cmd, format)
         gt_logger.gt_log_tab("hook command: %s"% cmd)
-        (_stdout, ret) = run_cli_command(cmd, shell=False)
+        (_stdout, ret) = self.run_cli_command_with_stdout(cmd, shell=False)
         print _stdout
         return ret
 

--- a/mbed_greentea/mbed_greentea_hooks.py
+++ b/mbed_greentea/mbed_greentea_hooks.py
@@ -74,7 +74,7 @@ class GreenteaCliTestHook(GreenteaTestHook):
         if _stdout:
             print _stdout
         if ret:
-            gt_logger.gt_err("hook exited with error: %d, dumping stderr..."% ret)
+            gt_logger.gt_log_err("hook exited with error: %d, dumping stderr..."% ret)
             print _stderr
         return ret
 

--- a/mbed_greentea/mbed_greentea_hooks.py
+++ b/mbed_greentea/mbed_greentea_hooks.py
@@ -19,11 +19,8 @@ Author: Przemyslaw Wirkus <Przemyslaw.wirkus@arm.com>
 
 import re
 import json
-from mbed_greentea.mbed_greentea_log import gt_log
-from mbed_greentea.mbed_greentea_log import gt_bright
-from mbed_greentea.mbed_greentea_log import gt_log_tab
-from mbed_greentea.mbed_greentea_log import gt_log_err
 from mbed_greentea.mbed_test_api import run_cli_command
+from mbed_greentea.mbed_greentea_log import gt_logger
 
 """
 List of available hooks:
@@ -55,9 +52,9 @@ class GreenteaCliTestHook(GreenteaTestHook):
         @format Pass format dictionary to replace hook {tags} with real values
         @param format Used to format string with cmd, notation used is e.g: {build_name}
         """
-        gt_log("hook '%s' execution"% self.name)
+        gt_logger.gt_log("hook '%s' execution"% self.name)
         cmd = self.format_before_run(self.cmd, format)
-        gt_log_tab("hook command: %s"% cmd)
+        gt_logger.gt_log_tab("hook command: %s"% cmd)
         return run_cli_command(cmd, shell=False)
 
     @staticmethod
@@ -68,11 +65,11 @@ class GreenteaCliTestHook(GreenteaTestHook):
             if cmd_expand:
                 cmd = cmd_expand
                 if verbose:
-                    gt_log_tab("hook expanded: %s"% cmd)
+                    gt_logger.gt_log_tab("hook expanded: %s"% cmd)
 
             cmd = cmd.format(**format)
             if verbose:
-                gt_log_tab("hook formated: %s"% cmd)
+                gt_logger.gt_log_tab("hook formated: %s"% cmd)
         return cmd
 
     @staticmethod

--- a/mbed_greentea/mbed_greentea_hooks.py
+++ b/mbed_greentea/mbed_greentea_hooks.py
@@ -19,6 +19,7 @@ Author: Przemyslaw Wirkus <Przemyslaw.wirkus@arm.com>
 
 import re
 import json
+import subprocess
 from mbed_greentea.mbed_test_api import run_cli_command
 from mbed_greentea.mbed_greentea_log import gt_logger
 
@@ -47,6 +48,20 @@ class GreenteaCliTestHook(GreenteaTestHook):
         GreenteaTestHook.__init__(self, name)
         self.cmd = cmd
 
+    def run_cli_command_with_stdout(self, cmd, shell=False):
+        """! Execute command with stdout
+        """
+        result = True
+        _stdout = None
+        try:
+            _stdout = subprocess.check_output(cmd,
+                stderr=subprocess.STDOUT,
+                shell=shell)
+        except subprocess.CalledProcessError as e:
+            print str(e)
+            result = False
+        return (_stdout, result)
+
     def run(self, format=None):
         """! Runs hook after command is formated with in-place {tags}
         @format Pass format dictionary to replace hook {tags} with real values
@@ -55,7 +70,9 @@ class GreenteaCliTestHook(GreenteaTestHook):
         gt_logger.gt_log("hook '%s' execution"% self.name)
         cmd = self.format_before_run(self.cmd, format)
         gt_logger.gt_log_tab("hook command: %s"% cmd)
-        return run_cli_command(cmd, shell=False)
+        (_stdout, ret) = run_cli_command(cmd, shell=False)
+        print _stdout
+        return ret
 
     @staticmethod
     def format_before_run(cmd, format, verbose=False):

--- a/mbed_greentea/mbed_greentea_hooks.py
+++ b/mbed_greentea/mbed_greentea_hooks.py
@@ -56,19 +56,24 @@ class GreenteaCliTestHook(GreenteaTestHook):
         @param format Used to format string with cmd, notation used is e.g: {build_name}
         """
         gt_log("hook '%s' execution"% self.name)
-        cmd = self.cmd
-        if format:
-            # We will expand first
-            cmd_expand = self.expand_parameters(cmd, format)
-            if cmd_expand:
-                cmd = cmd_expand
-                gt_log_tab("hook expanded: %s"% cmd)
-
-            cmd = cmd.format(**format)
-            gt_log_tab("hook formated: %s"% cmd)
-
+        cmd = self.format_before_run(self.cmd, format, verbose=True)
         gt_log_tab("hook command: %s"% cmd)
         return run_cli_command(cmd, shell=False)
+
+    @staticmethod
+    def format_before_run(cmd, format, verbose=False):
+        if format:
+            # We will expand first
+            cmd_expand = GreenteaCliTestHook.expand_parameters(cmd, format)
+            if cmd_expand:
+                cmd = cmd_expand
+                if verbose:
+                    gt_log_tab("hook expanded: %s"% cmd)
+
+            cmd = cmd.format(**format)
+            if verbose:
+                gt_log_tab("hook formated: %s"% cmd)
+        return cmd
 
     @staticmethod
     def expand_parameters(expr, expandables, delimiter=' '):

--- a/mbed_greentea/mbed_greentea_hooks.py
+++ b/mbed_greentea/mbed_greentea_hooks.py
@@ -73,6 +73,8 @@ class GreenteaCliTestHook(GreenteaTestHook):
         (_stdout, _stderr, ret) = self.run_cli_process(cmd)
         if _stdout:
             print _stdout
+        if ret:
+            gt_logger.gt_err("hook exited with error: %d, dumping stderr..."% ret)
             print _stderr
         return ret
 

--- a/mbed_greentea/mbed_greentea_hooks.py
+++ b/mbed_greentea/mbed_greentea_hooks.py
@@ -47,7 +47,7 @@ class GreenteaCliTestHook(GreenteaTestHook):
         GreenteaTestHook.__init__(self, name)
         self.cmd = cmd
 
-    def run_cli_command_with_stdout(self, cmd, shell=False):
+    def run_cli_command_with_stdout(self, cmd, shell=True):
         """! Execute command with stdout
         """
         result = True
@@ -70,7 +70,8 @@ class GreenteaCliTestHook(GreenteaTestHook):
         cmd = self.format_before_run(self.cmd, format)
         gt_logger.gt_log_tab("hook command: %s"% cmd)
         (_stdout, ret) = self.run_cli_command_with_stdout(cmd, shell=False)
-        print _stdout
+        if _stdout:
+            print _stdout
         return ret
 
     @staticmethod

--- a/mbed_greentea/mbed_greentea_hooks.py
+++ b/mbed_greentea/mbed_greentea_hooks.py
@@ -56,7 +56,7 @@ class GreenteaCliTestHook(GreenteaTestHook):
         @param format Used to format string with cmd, notation used is e.g: {build_name}
         """
         gt_log("hook '%s' execution"% self.name)
-        cmd = self.format_before_run(self.cmd, format, verbose=True)
+        cmd = self.format_before_run(self.cmd, format)
         gt_log_tab("hook command: %s"% cmd)
         return run_cli_command(cmd, shell=False)
 

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -389,6 +389,24 @@ def run_host_test(image_path,
         """
         return None
 
+    def dump_file(self, path, payload):
+        """! Creates file and dumps payload to it on specified path (even if path doesn't exist)
+        @param path Path to file
+        @param payload Data to store in a file
+        @return True if operation was completed
+        """
+        result = True
+        try:
+            d = os.path.dirname(path)
+            if not os.path.exists(d):
+                os.makedirs(d)
+            with open(path, "wb") as f:
+                f.write(bin_payload)
+        except IOError as e:
+            print str(e)
+            result = False
+        return result
+
     # We may have code coverage data to dump from test prints
     if coverage_start_data_list:
         gt_logger.gt_log("storing coverage data artefacts")
@@ -403,8 +421,7 @@ def run_host_test(image_path,
                 bin_payload = pack_base64_payload(path, payload)
             if bin_payload:
                 gt_logger.gt_log_tab("storing %d bytes in '%s'"% (len(bin_payload), path))
-                with open(path, "wb") as f:
-                    f.write(bin_payload)
+                self.dump_file(path, bin_payload)
 
     if verbose:
         gt_logger.gt_log("mbed-host-test-runner: stopped")

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -421,7 +421,7 @@ def run_host_test(image_path,
                 bin_payload = pack_base64_payload(path, payload)
             if bin_payload:
                 gt_logger.gt_log_tab("storing %d bytes in '%s'"% (len(bin_payload), path))
-                self.dump_file(path, bin_payload)
+                dump_file(path, bin_payload)
 
     if verbose:
         gt_logger.gt_log("mbed-host-test-runner: stopped")

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -389,7 +389,7 @@ def run_host_test(image_path,
         """
         return None
 
-    def dump_file(self, path, payload):
+    def dump_file(path, payload):
         """! Creates file and dumps payload to it on specified path (even if path doesn't exist)
         @param path Path to file
         @param payload Data to store in a file

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -373,7 +373,7 @@ def run_host_test(image_path,
 
     # We may have code coverage data to dump from test prints
     if coverage_start_data_list:
-        gt_log("storing coverage data artefacts")
+        gt_logger.gt_log("storing coverage data artefacts")
         for cov_data in coverage_start_data_list:
             path = os.path.abspath(cov_data['path'])
             payload = cov_data['payload']
@@ -384,7 +384,7 @@ def run_host_test(image_path,
             else:
                 bin_payload = pack_base64_payload(path, payload)
             if bin_payload:
-                gt_log_tab("storing %d bytes in '%s'"% (len(bin_payload), path))
+                gt_logger.gt_log_tab("storing %d bytes in '%s'"% (len(bin_payload), path))
                 with open(path, "wb") as f:
                     f.write(bin_payload)
 

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -265,9 +265,12 @@ def run_host_test(image_path,
     coverage_start_data_list = []   # List of code coverage reports to dump
 
     result = None
-    update_once_flag = {}   # Stores flags checking if some auto-parameter was already set
+    update_once_flag = {}       # Stores flags checking if some auto-parameter was already set
     unknown_property_count = 0
-    total_duration = 20     # This for flashing, reset and other serial port operations
+    TOTAL_DURATION = 30         # This for flashing, reset and other serial port operations
+    COVERAGE_EXTRA_TIME = 20    # Extra time for coverage dump
+
+    total_duration = TOTAL_DURATION
     line = ''
     output = []
     start_time = time()
@@ -326,6 +329,7 @@ def run_host_test(image_path,
                 if line.startswith("{{coverage_start"):
                     coverage_start_line = line.strip("{}")  # Remove {{ }} delimiters
                     coverage_start_data = coverage_start_line.split(";")
+                    total_duration += COVERAGE_EXTRA_TIME   # Increase timeout to get extra lcov data
 
                 # Check for test end
                 if '{end}' in line:

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -20,8 +20,6 @@ Author: Przemyslaw Wirkus <Przemyslaw.wirkus@arm.com>
 import os
 import re
 import sys
-import binascii
-from time import sleep
 from time import time
 from Queue import Queue, Empty
 from threading import Thread

--- a/test/mbed_gt_hooks.py
+++ b/test/mbed_gt_hooks.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+"""
+mbed SDK
+Copyright (c) 2011-2015 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+from mbed_greentea.mbed_greentea_hooks import GreenteaCliTestHook
+
+class GreenteaCliTestHookTest(unittest.TestCase):
+
+    def setUp(self):
+        self.cli_hooks = GreenteaCliTestHook('test_hook', 'some command')
+
+    def tearDown(self):
+        pass
+
+    def test_expand_parameters_with_1_list(self):
+        # Simple list
+        self.assertEqual('new_value_1 new_value_2',
+            self.cli_hooks.expand_parameters('[{token_list}]', {
+                "token_list" : ['new_value_1', 'new_value_2']
+            }))
+
+        # List with prefix
+        self.assertEqual('-a new_value_1 -a new_value_2',
+            self.cli_hooks.expand_parameters('[-a {token_list}]', {
+                "token_list" : ['new_value_1', 'new_value_2']
+            }))
+
+        # List with prefix and extra text
+        self.assertEqual('-a /path/to/new_value_1 -a /path/to/new_value_2',
+            self.cli_hooks.expand_parameters('[-a /path/to/{token_list}]', {
+                "token_list" : ['new_value_1', 'new_value_2']
+            }))
+
+    def test_expand_parameters_with_2_lists(self):
+        self.assertEqual('ytA T1',
+            self.cli_hooks.expand_parameters('[{yt_target_list} {test_list}]', {
+                "test_list" : ['T1'],
+                "yt_target_list" : ['ytA'],
+            }))
+
+        self.assertEqual('ytA T1 ytA T2 ytA T3 ytB T1 ytB T2 ytB T3 ytC T1 ytC T2 ytC T3',
+            self.cli_hooks.expand_parameters('[{yt_target_list} {test_list}]', {
+                "test_list" : ['T1', 'T2', 'T3'],
+                "yt_target_list" : ['ytA', 'ytB', 'ytC'],
+            }))
+
+        # In this test we expect {yotta_target_name} token to stay untouched because it is not declared as a list
+        self.assertEqual('lcov -a /build/{yotta_target_name}/mbed-drivers-test-basic.info -a /build/{yotta_target_name}/mbed-drivers-test-hello.info',
+            self.cli_hooks.expand_parameters('lcov [-a /build/{yotta_target_name}/{test_list}.info]', {
+                "test_list" : ['mbed-drivers-test-basic', 'mbed-drivers-test-hello'],
+                "yotta_target_name" : 'frdm-k64f-gcc'
+            }))
+
+    def test_expand_parameters_exceptions(self):
+        # Here [] is reduced to empty string
+        self.assertEqual('',
+            self.cli_hooks.expand_parameters('[]', {
+                "test_list" : ['mbed-drivers-test-basic', 'mbed-drivers-test-hello'],
+                "yotta_target_name" : 'frdm-k64f-gcc'
+            }))
+
+        # Here [some string] is reduced to empty string
+        self.assertEqual('',
+            self.cli_hooks.expand_parameters('[some string]', {
+                "test_list" : ['mbed-drivers-test-basic', 'mbed-drivers-test-hello'],
+                "yotta_target_name" : 'frdm-k64f-gcc'
+            }))
+
+        # Here [some string] is reduced to empty string
+        self.assertEqual('-+=abc',
+            self.cli_hooks.expand_parameters('-+=[some string]abc', {
+                "test_list" : ['mbed-drivers-test-basic', 'mbed-drivers-test-hello'],
+                "yotta_target_name" : 'frdm-k64f-gcc'
+            }))
+
+        self.assertEqual(None,
+            self.cli_hooks.expand_parameters('some text without square brackets but with tokes: {test_list} and {yotta_target_name}', {
+                "test_list" : ['mbed-drivers-test-basic', 'mbed-drivers-test-hello'],
+                "yotta_target_name" : 'frdm-k64f-gcc'
+            }))
+
+    def test_format_before_run_with_1_list_1_string(self):
+        # {test_name_list} should expand [] list twice
+        # {yotta_target_name} should not be used to expand, only to replace
+        self.assertEqual('build path = -a /build/frdm-k64f-gcc/mbed-drivers-test-basic -a /build/frdm-k64f-gcc/mbed-drivers-test-hello',
+            self.cli_hooks.format_before_run('build path = [-a /build/{yotta_target_name}/{test_name_list}]', {
+                "test_name_list" : ['mbed-drivers-test-basic', 'mbed-drivers-test-hello'],
+                "yotta_target_name" : 'frdm-k64f-gcc',
+            }))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/mbed_gt_test_parallel.py
+++ b/test/mbed_gt_test_parallel.py
@@ -156,6 +156,7 @@ class GtOptions:
                  report_fails=False,
                  verbose_test_result_only=False,
                  enum_host_tests=None,
+                 hooks_json=None,
                  verbose=True,
                  version=False):
 
@@ -181,6 +182,7 @@ class GtOptions:
         self.report_fails = report_fails
         self.verbose_test_result_only = verbose_test_result_only
         self.enum_host_tests = enum_host_tests
+        self.hooks_json = hooks_json
         self.verbose = verbose
         self.version = version
 


### PR DESCRIPTION
# Description
This PR is a response to https://github.com/ARMmbed/greentea/issues/32 and introduces support for extra block of data with code coverage payload.

Two new delimiters are introduced in test case console output:
*  ```{{coverage_start}}``` which starts coverage block and
* ending payload delimiter ```{{coverage_end}}```.

Each coverage block should have 2 lines:
* Line 1: ```{{coverage_start;PATH}}``` where PATH is path to payload destination file
* Line 2: ```PAYLOAD{{coverage_end}}``` where PAYLOAD is hex ascii encoded binary data.

**Note** that currently supported PAYLOAD encoding is ```hex ascii```.

## Coverage block example
```
{{coverage_start;/path/to/lcov_file.c.gcda}}
616463677238303436e9841b000000a370000000743e2891d40d0000{{coverage_end}}
```
Where:
* PATH to payload file: ```/path/to/lcov_file.c.gcda```
* PAYLOAD ```616463677238303436e9841b000000a370000000743e2891d40d0000```

## Multiple coverage block example
```
{{coverage_start;/path/to/lcov_file_1.c.gcda}}
616463677238303436e9841b000000a370000000743e2891d40d0000{{coverage_end}}
{{coverage_start;/path/to/lcov_file_2.c.gcda}}
1000000b67a0500000000001fae0000000000001fae000000000000f{{coverage_end}}
```
* Note: Corresponding greentea log
```
mbedgt: storing coverage data artefacts
        storing 28 bytes in '/path/to/lcov_file_1.c.gcda'
        storing 28 bytes in '/path/to/lcov_file_2.c.gcda'
```

## Hooks support
Users can hook commands to few events during testing. Hooks commands are passed to Greentea using JSON configuration file declared with ```---hooks``` command line switch.

Note, for some tags (in curly braces) users can use statements wrapped around ```[ ]``` to expand lists of e.g. test cases executed during test run.

### Example of hook definition passing via JSON file:
```
$ mbedgt -V --hooks lcovhooks.json ...
```

### Example configuration file (example name ```lcovhooks.json```):
```json
{
    "hooks": {
        "hook_test_end": "$echo test name = {test_name}, build path = {build_path_abs}",
        "hook_post_test_end": "$echo build path = {build_path_abs}",
        "hook_post_all_test_end": "$echo build path = [-a /build/{yotta_target_name}/{test_name_list}]"
    }
}
```

Note: All console commands start with dollar sign ```$```.

For this feature I've added new simple hooking mechanism which will allow users call command line programs during particular events:

* Test case hook ```hook_test_end```:
  * Executed just after test case execution is finished.
  * Executed only if test status is ```OK```
  * Available tags for command format :
    * ```{test_name}```, 
    * ```{test_bin_name}```, 
    * ```{image_path}```, 
    * ```{build_path}```, 
    * ```{build_path_abs}```, 
    * ```{yotta_target_name}```.
* Test case hook ```hook_post_test_end``` .
  * Executed after all tests finished.
  * Executed for each test one by one only if test status is ```OK```
  * Available tags for command format :
    * ```{test_name}```, 
    * ```{test_bin_name}```, 
    * ```{image_path}```, 
    * ```{build_path}```, 
    * ```{build_path_abs}```, 
    * ```{yotta_target_name}```.
* Test case hook ```hook_post_all_test_end```.
  * Executed after all tests finished.
  * Executes for each yotta target specified in test
  * Available tags for command format :
    * ```{build_path}```,
    * ```{build_path_abs}```,
    * ```{test_name_list}``` - will be expanded in claused insinde ```[``` ```]```,
    * ```{yotta_target_name}```.

### Example of command parse options
In this example we are calling tests with:
* Greentea: ```mbedgt -V --hooks lcovhooks.json -n mbed-drivers-test-basic,mbed-drivers-test-detect```
* Current directory is: ```c:\Work\mbed-drivers```
* yotta target: ```frdm-k64f-gcc```
* Test executed: ```mbed-drivers-test-basic```
```
        {build_path} -> './build\frdm-k64f-gcc'
        {image_path} -> '.\build\frdm-k64f-gcc\test\mbed-drivers-test-basic.bin'
        {build_path_abs} -> 'c:\Work\mbed-drivers\build\frdm-k64f-gcc'
        {yotta_target_name} -> 'frdm-k64f-gcc'
        {test_name} -> 'mbed-drivers-test-basic'
        {test_name_list} -> ['mbed-drivers-test-basic', 'mbed-drivers-test-detect']
        {test_bin_name} -> 'mbed-drivers-test-basic.bin'
```

Hooks ```lcovhooks.json``` configuration file:
```json
{
    "hooks": {
        "hook_test_end": "$echo test name = {test_name}, build path = {build_path_abs}",
        "hook_post_test_end": "$echo build path = {build_path_abs}",
        "hook_post_all_test_end": "$echo build path = [-a /build/{yotta_target_name}/{test_name_list}]"
    }
}
```

* Hook ```hook_test_end``` command:
```
mbedgt: hook 'hook_test_end' execution
        hook command: echo test name = mbed-drivers-test-basic, build path = c:\Work\mbed-drivers\build\frdm-k64f-gcc
test name = mbed-drivers-test-basic, build path = c:\Work\mbed-drivers\build\frdm-k64f-gcc
```
```
mbedgt: hook 'hook_test_end' execution
        hook command: echo test name = mbed-drivers-test-detect, build path = c:\Work\mbed-drivers\build\frdm-k64f-gcc
test name = mbed-drivers-test-detect, build path = c:\Work\mbed-drivers\build\frdm-k64f-gcc
```
* Hook ```hook_post_test_end``` command:
```
mbedgt: hook 'hook_post_test_end' execution
        hook command: echo build path = c:\Work\mbed-drivers\build\frdm-k64f-gcc
build path = c:\Work\mbed-drivers\build\frdm-k64f-gcc
mbedgt: hook 'hook_post_test_end' execution
        hook command: echo build path = c:\Work\mbed-drivers\build\frdm-k64f-gcc
build path = c:\Work\mbed-drivers\build\frdm-k64f-gcc
```
* Hook ```hook_post_all_test_end``` command:
```
mbedgt: hook 'hook_post_all_test_end' execution
        hook command: echo build path = -a /build/frdm-k64f-gcc/mbed-drivers-test-basic -a /build/frdm-k64f-gcc/mbed-drivers-test-detect
build path = -a /build/frdm-k64f-gcc/mbed-drivers-test-basic -a /build/frdm-k64f-gcc/mbed-drivers-test-detect
```

# Example for mbed-drivers module
* Enable code coverage and set output serial port baudrate to 11500 - testconfig.json:
```json
{
    "debug":{
        "options" : {
            "coverage" : {
                "modules" : {
                    "mbed-drivers" : true
                }
            }
        }
    },

    "mbed-os": {
        "stdio": {
            "default-baud": 115200
            }
        }
}

```

* lcovhooks.json:
```json
{
    "hooks": {
        "hook_test_end": "$lcov --gcov-tool arm-none-eabi-gcov  --capture --directory ./build --output-file ./build/{yotta_target_name}/{test_name}.info",
        "hook_post_test_end": "$echo lcov --gcov-tool arm-none-eabi-gcov  --capture --directory ./build --output-file ./build/{yotta_target_name}/{test_name}.info",
        "hook_post_all_test_end": "$lcov --gcov-tool arm-none-eabi-gcov [-a ./build/{yotta_target_name}/{test_name_list}.info] --output-file result.info"
    }
}
```

* Workflow used to run code coverage session:
```
$ cd mbed-drivers
$ yt build --config testconfig.json
$ sudo mbedgt -V --hooks lcovhooks.json --skip-build
```

Finally, you can generate code coverage HTML report to ```htmlcov``` directory:
```
$ genhtml result.info --output-directory htmlcov
```

Where:
* ```--hooks lcovhooks.json``` - add hooks to gather ```gcov``` / ```lcov``` results.
* ```--skip-build``` - do not rebuild to reuse build with coverage turned on (see: ```yt build --config testconfig.json```).
