### PR TITLE
Add yotta config parse

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -42,7 +42,7 @@ from mbed_greentea.mbed_greentea_dlm import greentea_get_app_sem
 from mbed_greentea.mbed_greentea_dlm import greentea_update_kettle
 from mbed_greentea.mbed_greentea_dlm import greentea_clean_kettle
 from mbed_greentea.mbed_yotta_api import build_with_yotta
-from mbed_yotta_target_parse import YottaConfig
+from mbed_greentea.mbed_yotta_target_parse import YottaConfig
 
 try:
     import mbed_lstools

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -42,7 +42,7 @@ from mbed_greentea.mbed_greentea_dlm import greentea_get_app_sem
 from mbed_greentea.mbed_greentea_dlm import greentea_update_kettle
 from mbed_greentea.mbed_greentea_dlm import greentea_clean_kettle
 from mbed_greentea.mbed_yotta_api import build_with_yotta
-
+from mbed_yotta_target_parse import YottaConfig
 
 try:
     import mbed_lstools
@@ -253,7 +253,12 @@ def run_test_thread(test_result_queue, test_queue, opts, mut, mut_info, yotta_ta
     test_exec_retcode = 0
     test_platforms_match = 0
     test_report = {}
-    #greentea_acquire_target_id(mut['target_id'], gt_instance_uuid)
+    yotta_config_baudrate = None    # Default serial port baudrate forced by configuration
+
+    yotta_config = YottaConfig()
+    yotta_config.init(yotta_target_name)
+
+    yotta_config_baudrate = yotta_config.get_baudrate()
 
     while not test_queue.empty():
         try:
@@ -271,6 +276,10 @@ def run_test_thread(test_result_queue, test_queue, opts, mut, mut_info, yotta_ta
         copy_method = opts.copy_method if opts.copy_method else 'shell'
         verbose = opts.verbose_test_result_only
         enum_host_tests_path = get_local_host_tests_dir(opts.enum_host_tests)
+
+        # We will force configuration specific baudrate
+        if port:
+            port = "%s:%d"% (port, yotta_config_baudrate)
 
         test_platforms_match += 1
         #gt_log_tab("running host test...")
@@ -524,6 +533,15 @@ def main_cli(opts, args, gt_instance_uuid=None):
                     program_cycle_s = mut_info_map[platfrom_name]['properties']['program_cycle_s']
                     copy_method = opts.copy_method if opts.copy_method else 'shell'
                     enum_host_tests_path = get_local_host_tests_dir(opts.enum_host_tests)
+
+                    yotta_config = YottaConfig()
+                    yotta_config.init(yotta_target_name)
+
+                    yotta_config_baudrate = yotta_config.get_baudrate()
+
+                    # We will force configuration specific baudrate
+                    if port:
+                        port = "%s:%d"% (port, yotta_config_baudrate)
 
                     test_platforms_match += 1
                     host_test_result = run_host_test(opts.run_app,

--- a/mbed_greentea/mbed_yotta_target_parse.py
+++ b/mbed_greentea/mbed_yotta_target_parse.py
@@ -42,6 +42,9 @@ class YottaConfig():
             self.yotta_config = {}
         return bool(len(self.yotta_config))
 
+    def set_yotta_config(self, yotta_config):
+        self.yotta_config = yotta_config
+
     def get_baudrate(self):
         """! Returns default baudrate for stdio serial
         @return Configuration baudrate of default on (115200)
@@ -63,14 +66,14 @@ class YottaConfig():
           },
         """
         # Get default baudrate for this target
-        if 'mbed-os' in self.yotta_config:
+        if self.yotta_config and 'mbed-os' in self.yotta_config:
             if 'stdio' in self.yotta_config['mbed-os']:
                 if 'default-baud' in self.yotta_config['mbed-os']['stdio']:
                     return int(self.yotta_config['mbed-os']['stdio']['default-baud'])
         return self.DEFAULT_BAUDRATE
 
     def get_test_pins(self):
-        if 'hardware' in self.yotta_config:
+        if self.yotta_config and 'hardware' in self.yotta_config:
             if 'test-pins' in self.yotta_config['hardware']:
                 return self.yotta_config['hardware']['test-pins']
         return None

--- a/mbed_greentea/mbed_yotta_target_parse.py
+++ b/mbed_greentea/mbed_yotta_target_parse.py
@@ -28,6 +28,7 @@ class YottaConfig():
     def __init__(self):
         self.BUILD_DIR = 'build'
         self.YOTTA_CONFIG_NAME = 'yotta_config.json'
+        self.DEFAULT_BAUDRATE = 115200
 
     def init(self, target_name):
         """! Loads yotta_config.json as an object from local yotta build directory
@@ -43,7 +44,7 @@ class YottaConfig():
 
     def get_baudrate(self):
         """! Returns default baudrate for stdio serial
-        @return None if baudrate not found, else boudrate
+        @return Configuration baudrate of default on (115200)
         Example yotta_config.json
         {
           "minar": {
@@ -66,7 +67,7 @@ class YottaConfig():
             if 'stdio' in self.yotta_config['mbed-os']:
                 if 'default-baud' in self.yotta_config['mbed-os']['stdio']:
                     return int(self.yotta_config['mbed-os']['stdio']['default-baud'])
-        return None
+        return self.DEFAULT_BAUDRATE
 
     def get_test_pins(self):
         if 'hardware' in self.yotta_config:

--- a/mbed_greentea/mbed_yotta_target_parse.py
+++ b/mbed_greentea/mbed_yotta_target_parse.py
@@ -1,0 +1,75 @@
+"""
+mbed SDK
+Copyright (c) 2011-2015 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Author: Przemyslaw Wirkus <Przemyslaw.Wirkus@arm.com>
+"""
+
+import os
+import json
+
+
+class YottaConfig():
+
+    yotta_config = None
+
+    def __init__(self):
+        self.BUILD_DIR = 'build'
+        self.YOTTA_CONFIG_NAME = 'yotta_config.json'
+
+    def init(self, target_name):
+        """! Loads yotta_config.json as an object from local yotta build directory
+        @return True if data was successfuly loaded from the file
+        """
+        try:
+            path = os.path.join(self.BUILD_DIR, target_name, self.YOTTA_CONFIG_NAME)
+            with open(path, 'r') as data_file:
+                self.yotta_config = json.load(data_file)
+        except IOError as e:
+            self.yotta_config = {}
+        return bool(len(self.yotta_config))
+
+    def get_baudrate(self):
+        """! Returns default baudrate for stdio serial
+        @return None if baudrate not found, else boudrate
+        Example yotta_config.json
+        {
+          "minar": {
+            "initial_event_pool_size": 50,
+            "additional_event_pools_size": 100
+          },
+          "mbed-os": {
+            "net": {
+              "stacks": {
+                "lwip": true
+              }
+            },
+            "stdio": {
+              "default-baud": 9600
+            }
+          },
+        """
+        # Get default baudrate for this target
+        if 'mbed-os' in self.yotta_config:
+            if 'stdio' in self.yotta_config['mbed-os']:
+                if 'default-baud' in self.yotta_config['mbed-os']['stdio']:
+                    return int(self.yotta_config['mbed-os']['stdio']['default-baud'])
+        return None
+
+    def get_test_pins(self):
+        if 'hardware' in self.yotta_config:
+            if 'test-pins' in self.yotta_config['hardware']:
+                return self.yotta_config['hardware']['test-pins']
+        return None

--- a/test/mbed_gt_test_parallel.py
+++ b/test/mbed_gt_test_parallel.py
@@ -216,3 +216,5 @@ class MbedsMock:
         return {'K64F': 2}
 
 
+if __name__ == '__main__':
+    unittest.main()

--- a/test/mbed_gt_yotta_config.py
+++ b/test/mbed_gt_yotta_config.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+"""
+mbed SDK
+Copyright (c) 2011-2015 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+from mbed_greentea.mbed_yotta_target_parse import YottaConfig
+
+class YOttaConfigurationParse(unittest.TestCase):
+
+    def setUp(self):
+        self.YOTTA_CONFIG_LONG = {
+          "minar": {
+            "initial_event_pool_size": 50,
+            "additional_event_pools_size": 100
+          },
+          "mbed-os": {
+            "net": {
+              "stacks": {
+                "lwip": True
+              }
+            },
+            "stdio": {
+              "default-baud": 9600
+            }
+          },
+          "cmsis": {
+            "nvic": {
+              "ram_vector_address": "0x1FFF0000",
+              "flash_vector_address": "0x0",
+              "user_irq_offset": 16,
+              "user_irq_number": 86
+            }
+          },
+          "hardware": {
+            "pins": {
+              "LED_RED": "PTB22",
+              "LED_GREEN": "PTE26",
+              "LED_BLUE": "PTB21",
+              "LED1": "LED_RED",
+              "LED2": "LED_GREEN",
+              "LED3": "LED_BLUE",
+              "LED4": "LED_RED",
+              "SW2": "PTC6",
+              "SW3": "PTA4",
+              "USBTX": "PTB17",
+              "USBRX": "PTB16",
+              "D0": "PTC16",
+              "D1": "PTC17",
+              "D2": "PTB9",
+              "D3": "PTA1",
+              "D4": "PTB23",
+              "D5": "PTA2",
+              "D6": "PTC2",
+              "D7": "PTC3",
+              "D8": "PTA0",
+              "D9": "PTC4",
+              "D10": "PTD0",
+              "D11": "PTD2",
+              "D12": "PTD3",
+              "D13": "PTD1",
+              "D14": "PTE25",
+              "D15": "PTE24",
+              "I2C_SCL": "D15",
+              "I2C_SDA": "D14",
+              "A0": "PTB2",
+              "A1": "PTB3",
+              "A2": "PTB10",
+              "A3": "PTB11",
+              "A4": "PTC10",
+              "A5": "PTC11",
+              "DAC0_OUT": "0xFEFE"
+            },
+            "test-pins": {
+              "spi": {
+                "mosi": "PTD2",
+                "miso": "PTD3",
+                "sclk": "PTD1",
+                "ssel": "PTD0"
+              },
+              "i2c": {
+                "sda": "PTE25",
+                "scl": "PTE24"
+              },
+              "serial": {
+                "tx": "PTC17",
+                "rx": "PTD2"
+              }
+            }
+          },
+          "uvisor": {
+            "present": 1
+          },
+          "arch": {
+            "arm": {}
+          },
+          "mbed": {}
+        }
+
+        self.YOTTA_CONFIG_SHORT = {
+          "minar": {
+            "initial_event_pool_size": 50,
+            "additional_event_pools_size": 100
+          },
+          "mbed-os": {
+            "net": {
+              "stacks": {
+                "lwip": True
+              }
+            },
+            "stdio": {
+              "default-baud": 38400
+            }
+          },
+          "cmsis": {
+            "nvic": {
+              "ram_vector_address": "0x1FFF0000",
+              "flash_vector_address": "0x0",
+              "user_irq_offset": 16,
+              "user_irq_number": 86
+            }
+          },
+        }
+
+    def tearDown(self):
+        pass
+
+    def test_get_baudrate_9600(self):
+        yotta_config = YottaConfig()
+        yotta_config.set_yotta_config(self.YOTTA_CONFIG_LONG)
+        self.assertEqual(yotta_config.get_baudrate(), 9600)
+
+    def test_get_baudrate_38400(self):
+        yotta_config = YottaConfig()
+        yotta_config.set_yotta_config(self.YOTTA_CONFIG_SHORT)
+        self.assertEqual(yotta_config.get_baudrate(), 38400)
+
+    def test_get_baudrate_default_115200(self):
+        yotta_config = YottaConfig()
+        self.assertEqual(115200, yotta_config.DEFAULT_BAUDRATE)
+
+    def test_get_baudrate_default_115200_no_yotta_config(self):
+        yotta_config = YottaConfig()
+        self.assertEqual(yotta_config.get_baudrate(), yotta_config.DEFAULT_BAUDRATE)
+
+    def test_get_baudrate_None(self):
+        yotta_config = YottaConfig()
+        yotta_config.set_yotta_config(None)
+        self.assertEqual(yotta_config.get_baudrate(), yotta_config.DEFAULT_BAUDRATE)
+        self.assertEqual(115200, yotta_config.DEFAULT_BAUDRATE)
+
+    def test_get_test_pins(self):
+        yotta_config = YottaConfig()
+        yotta_config.set_yotta_config(self.YOTTA_CONFIG_LONG)
+        self.assertEqual(yotta_config.get_baudrate(), 9600)
+        self.assertIn('spi', yotta_config.get_test_pins())
+        self.assertIn('i2c', yotta_config.get_test_pins())
+        self.assertIn('serial', yotta_config.get_test_pins())
+        
+        
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Changes
* Add yotta_config.json parsing support.
  * ```yotta_config::mbed-os::stdio::default-baud``` setting read.
* Change dafault yotta connfiguration baudrate (```default-baud```) to ```115200```.

Example yotta configuration with baudrate
```json
{
  "minar": {
    "initial_event_pool_size": 50,
    "additional_event_pools_size": 100
  },
  "mbed-os": {
    "net": {
      "stacks": {
        "lwip": true
      }
    },
    "stdio": {
      "default-baud": 9600
    }
  },
}
```

## Dependencies
This feature is using extended port configuration in ```mbed-host-tests```
* https://github.com/ARMmbed/htrun/pull/34 and exact related commit
* https://github.com/ARMmbed/htrun/commit/a0d5297489b442c389072b04c60dfdac435eacb7

## Implications
```mbedhtrun``` will be called with a baudrate added to serial port command line switch, here ```-p COM172:9600```:
```
mbedhtrun -d G: -p COM172:9600 -f ".\core-util-test-functionpointer.bin" -C 4 -c shell -m K64F
```

See example call for one host test execution:
```
mbedgt: mbed-host-test-runner: stopped
mbedgt: mbed-host-test-runner: returned 'OK'
mbedgt: test on hardware with target id: 0240022648cb1e77000000000000000000000000b512e3cf
        test 'core-util-test-eventhandler' ..................................................... OK in 6.75 sec
mbedgt: selecting test case observer...
        calling mbedhtrun: mbedhtrun -d G: -p COM172:9600 -f ".\core-util-test-functionpointer.bin" -C 4 -c shell -m K64F
mbedgt: mbed-host-test-runner: started
MBED: Instrumentation: "COM172" and disk: "G:"
HOST: Copy image onto target...
        1 file(s) copied.
HOST: Initialize serial port...
...port ready!
HOST: Reset target...
HOST: Detecting test case properties...
HOST: Error! No host test name defined in preamble

{{error}}
{{end}}
```