### PR TITLE
Add target info for NRF51822

### DIFF
--- a/mbed_greentea/mbed_target_info.py
+++ b/mbed_greentea/mbed_target_info.py
@@ -73,6 +73,20 @@ TARGET_INFO_MAPPING = {
                 "reset_method": "default",
                 "program_cycle_s": 4
             }
+        },
+    "NRF51822" : {
+        "yotta_targets": [
+                {
+                    "yotta_target": "mkit-gcc",
+                    "mbed_toolchain": "GCC_ARM"
+                }
+             ],
+        "properties" : {
+                "binary_type": "-combined.hex",
+                "copy_method": "shell",
+                "reset_method": "default",
+                "program_cycle_s": 4
+            }
         }
 }
 


### PR DESCRIPTION
With this Greentea can run tests on the [nRF51822-mKIT](https://www.mbed.com/en/development/hardware/boards/nordic/nrf51822/) board. Without this entry Greentea tries to load the .bin file, which do not work on the nRF51822-mKIT board.