### PR TITLE
Switch to ignore test cases

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -136,6 +136,7 @@ Note:
 
 * Use the option ```-V``` to display the serial port communication between the host computer and the mbed device on your console.
 * Use the option ```-n <test-name>``` to execute only a specific test (using name matching). You can use a comma to execute more than one test case. ```<test-name>``` is the name of the test case's binary (without an extension).
+* Use the option ```-i <test-name>``` to skip a specific test (using name matching). You can use a comma to skip more than one test case. ```<test-name>``` is the name of the test case's binary (without an extension).
 
 ### Notes
 * We've included ```mbed/test_env.h``` to get access to the generic mbed test's ```MBED_HOSTTEST_*``` macros. These macros are used to pass to the test suite information about the above test case. For example: 

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -654,11 +654,11 @@ def main_cli(opts, args, gt_instance_uuid=None):
                     ctest_test_list = load_ctest_testsuite(os.path.join('.', 'build', yotta_target_name),
                         binary_type=binary_type)
                     #TODO no tests to execute
-                
-                filtered_ctest_test_list = ctest_test_list
-                if opts.test_by_names or opts.skip_test:
-                    filtered_ctest_test_list = create_filtered_test_list(ctest_test_list, opts)
 
+                filtered_ctest_test_list = dict(ctest_test_list)
+                if opts.test_by_names or opts.skip_test:
+                    filtered_ctest_test_list = create_filtered_test_list(filtered_ctest_test_list, opts)
+                   
                 gt_logger.gt_log("running %d test%s for target '%s' and platform '%s'"% (
                     len(filtered_ctest_test_list),
                     "s" if len(filtered_ctest_test_list) != 1 else "",

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -134,7 +134,7 @@ def main():
                     dest='test_by_names',
                     help='Runs only test enumerated it this switch. Use comma to separate test case names.')
                     
-    parser.add_option('', '--skip-test',
+    parser.add_option('-i', '--skip-test',
                     dest='skip_test',
                     help='Skip tests enumerated it this switch. Use comma to separate test case names.')
                     

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -86,13 +86,15 @@ def print_version(verbose=True):
         print version
     return version
     
-def create_filtered_test_list(ctest_test_list, opts):
+def create_filtered_test_list(ctest_test_list, test_by_names, skip_test):
     filtered_ctest_test_list = ctest_test_list
     test_list = None
     invalid_test_names = []
-    if opts.test_by_names:
+    if filtered_ctest_test_list is None:
+        return {}
+    elif test_by_names:
         filtered_ctest_test_list = {}   # Subset of 'ctest_test_list'
-        test_list = opts.test_by_names.split(',')
+        test_list = test_by_names.split(',')
         gt_logger.gt_log("test case filter (specified with -n option)")
 
         for test_name in test_list:
@@ -101,8 +103,8 @@ def create_filtered_test_list(ctest_test_list, opts):
             else:
                 gt_logger.gt_log_tab("test filtered in '%s'"% gt_logger.gt_bright(test_name))
                 filtered_ctest_test_list[test_name] = ctest_test_list[test_name]
-    elif opts.skip_test:
-        test_list = opts.skip_test.split(',')   
+    elif skip_test:
+        test_list = skip_test.split(',')   
         gt_logger.gt_log("test case filter (specified with --skip-build option)")
         
         for test_name in test_list:
@@ -113,7 +115,7 @@ def create_filtered_test_list(ctest_test_list, opts):
                 del filtered_ctest_test_list[test_name]
     
     if invalid_test_names:
-        opt_to_print = '-n' if opts.test_by_names else 'skip-build'
+        opt_to_print = '-n' if test_by_names else 'skip-build'
         gt_logger.gt_log_warn("invalid test case names (specified with '%s' option)"% opt_to_print)
         for test_name in invalid_test_names:
             gt_logger.gt_log_warn("test name '%s' not found in CTestTestFile.cmake (specified with '%s' option)"% (gt_logger.gt_bright(test_name),opt_to_print))
@@ -654,10 +656,8 @@ def main_cli(opts, args, gt_instance_uuid=None):
                     ctest_test_list = load_ctest_testsuite(os.path.join('.', 'build', yotta_target_name),
                         binary_type=binary_type)
                     #TODO no tests to execute
-
-                filtered_ctest_test_list = dict(ctest_test_list)
-                if opts.test_by_names or opts.skip_test:
-                    filtered_ctest_test_list = create_filtered_test_list(filtered_ctest_test_list, opts)
+                
+                filtered_ctest_test_list = create_filtered_test_list(ctest_test_list, opts.test_by_names, opts.skip_test)
                    
                 gt_logger.gt_log("running %d test%s for target '%s' and platform '%s'"% (
                     len(filtered_ctest_test_list),

--- a/test/mbed_gt_test_filtered_test_list.py
+++ b/test/mbed_gt_test_filtered_test_list.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+"""
+mbed SDK
+Copyright (c) 2011-2015 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+from mbed_greentea import mbed_greentea_cli
+
+class GreenteaFilteredTestList(unittest.TestCase):
+
+    def setUp(self):
+        self.ctest_test_list = {'test1': '\\build\\test1.bin',
+                                'test2': '\\build\\test2.bin',
+                                'test3': '\\build\\test3.bin',
+                                'test4': '\\build\\test4.bin'}
+
+    def tearDown(self):
+        pass
+
+    def test_skip_test(self):
+        gt_opts = GtOptions(skip_test='test1,test2')
+        filtered_ctest_test_list = mbed_greentea_cli.create_filtered_test_list(self.ctest_test_list, gt_opts)
+        
+        filtered_test_list = {'test3': '\\build\\test3.bin',
+                              'test4': '\\build\\test4.bin'}
+  
+        self.assertEqual(filtered_test_list, filtered_ctest_test_list)
+
+    def test_skip_test_invaild(self):
+        gt_opts = GtOptions(skip_test='test1,testXY')
+        filtered_ctest_test_list = mbed_greentea_cli.create_filtered_test_list(self.ctest_test_list, gt_opts)
+        
+        filtered_test_list = {'test2': '\\build\\test2.bin',
+                              'test3': '\\build\\test3.bin',
+                              'test4': '\\build\\test4.bin'}
+  
+        self.assertEqual(filtered_test_list, filtered_ctest_test_list)
+    
+    def test_test_by_names(self):
+        gt_opts = GtOptions(test_by_names='test3')
+        filtered_ctest_test_list = mbed_greentea_cli.create_filtered_test_list(self.ctest_test_list, gt_opts)
+        
+        filtered_test_list = {'test3': '\\build\\test3.bin'}
+  
+        self.assertEqual(filtered_test_list, filtered_ctest_test_list)
+        
+    def test_test_by_names_invalid(self):
+        gt_opts = GtOptions(test_by_names='test3,testXY')
+        filtered_ctest_test_list = mbed_greentea_cli.create_filtered_test_list(self.ctest_test_list, gt_opts)
+        
+        filtered_test_list = {'test3': '\\build\\test3.bin'}
+  
+        self.assertEqual(filtered_test_list, filtered_ctest_test_list)
+        
+    def test_test_by_names_and_skip_test(self):
+        gt_opts = GtOptions(test_by_names='test1', skip_test='test1,test2')
+        filtered_ctest_test_list = mbed_greentea_cli.create_filtered_test_list(self.ctest_test_list, gt_opts)
+        
+        filtered_test_list = {'test1': '\\build\\test1.bin'}
+  
+        self.assertEqual(filtered_test_list, filtered_ctest_test_list)
+        
+class GtOptions:
+    def __init__(self,
+                 test_by_names=None,
+                 skip_test=None):
+
+        self.test_by_names = test_by_names
+        self.skip_test = skip_test
+        
+if __name__ == '__main__':
+    unittest.main()

--- a/test/mbed_gt_test_filtered_test_list.py
+++ b/test/mbed_gt_test_filtered_test_list.py
@@ -26,60 +26,102 @@ class GreenteaFilteredTestList(unittest.TestCase):
                                 'test2': '\\build\\test2.bin',
                                 'test3': '\\build\\test3.bin',
                                 'test4': '\\build\\test4.bin'}
+        self.test_by_names = None
+        self.skip_test = None
 
     def tearDown(self):
         pass
 
+    def test_filter_test_list(self):
+        filtered_ctest_test_list = mbed_greentea_cli.create_filtered_test_list(self.ctest_test_list, 
+                                                                               self.test_by_names,
+                                                                               self.skip_test)
+        
+        filtered_test_list = {'test1': '\\build\\test1.bin',
+                              'test2': '\\build\\test2.bin',
+                              'test3': '\\build\\test3.bin',
+                              'test4': '\\build\\test4.bin'}
+        self.assertEqual(filtered_test_list, filtered_ctest_test_list)
+    
     def test_skip_test(self):
-        gt_opts = GtOptions(skip_test='test1,test2')
-        filtered_ctest_test_list = mbed_greentea_cli.create_filtered_test_list(self.ctest_test_list, gt_opts)
+        self.skip_test = 'test1,test2'
+        filtered_ctest_test_list = mbed_greentea_cli.create_filtered_test_list(self.ctest_test_list, 
+                                                                               self.test_by_names,
+                                                                               self.skip_test)
         
         filtered_test_list = {'test3': '\\build\\test3.bin',
                               'test4': '\\build\\test4.bin'}
-  
         self.assertEqual(filtered_test_list, filtered_ctest_test_list)
 
     def test_skip_test_invaild(self):
-        gt_opts = GtOptions(skip_test='test1,testXY')
-        filtered_ctest_test_list = mbed_greentea_cli.create_filtered_test_list(self.ctest_test_list, gt_opts)
+        self.skip_test='test1,testXY'
+        filtered_ctest_test_list = mbed_greentea_cli.create_filtered_test_list(self.ctest_test_list, 
+                                                                               self.test_by_names,
+                                                                               self.skip_test)
         
         filtered_test_list = {'test2': '\\build\\test2.bin',
                               'test3': '\\build\\test3.bin',
                               'test4': '\\build\\test4.bin'}
-  
         self.assertEqual(filtered_test_list, filtered_ctest_test_list)
     
     def test_test_by_names(self):
-        gt_opts = GtOptions(test_by_names='test3')
-        filtered_ctest_test_list = mbed_greentea_cli.create_filtered_test_list(self.ctest_test_list, gt_opts)
+        self.test_by_names='test3'
+        filtered_ctest_test_list = mbed_greentea_cli.create_filtered_test_list(self.ctest_test_list, 
+                                                                               self.test_by_names,
+                                                                               self.skip_test)
         
         filtered_test_list = {'test3': '\\build\\test3.bin'}
-  
         self.assertEqual(filtered_test_list, filtered_ctest_test_list)
         
     def test_test_by_names_invalid(self):
-        gt_opts = GtOptions(test_by_names='test3,testXY')
-        filtered_ctest_test_list = mbed_greentea_cli.create_filtered_test_list(self.ctest_test_list, gt_opts)
+        self.test_by_names='test3,testXY'
+        filtered_ctest_test_list = mbed_greentea_cli.create_filtered_test_list(self.ctest_test_list, 
+                                                                               self.test_by_names,
+                                                                               self.skip_test)
         
         filtered_test_list = {'test3': '\\build\\test3.bin'}
-  
         self.assertEqual(filtered_test_list, filtered_ctest_test_list)
+    
+    def test_list_is_None_skip_test(self):
+        self.ctest_test_list = None
+        self.skip_test='test3'
+        filtered_ctest_test_list = mbed_greentea_cli.create_filtered_test_list(self.ctest_test_list, 
+                                                                               self.test_by_names,
+                                                                               self.skip_test)
         
-    def test_test_by_names_and_skip_test(self):
-        gt_opts = GtOptions(test_by_names='test1', skip_test='test1,test2')
-        filtered_ctest_test_list = mbed_greentea_cli.create_filtered_test_list(self.ctest_test_list, gt_opts)
-        
-        filtered_test_list = {'test1': '\\build\\test1.bin'}
-  
+        filtered_test_list = {}
         self.assertEqual(filtered_test_list, filtered_ctest_test_list)
+    
+    def test_list_is_None_test_by_names(self):
+        self.ctest_test_list = None
+        self.test_by_names='test3'
+        filtered_ctest_test_list = mbed_greentea_cli.create_filtered_test_list(self.ctest_test_list, 
+                                                                               self.test_by_names,
+                                                                               self.skip_test)
         
-class GtOptions:
-    def __init__(self,
-                 test_by_names=None,
-                 skip_test=None):
-
-        self.test_by_names = test_by_names
-        self.skip_test = skip_test
+        filtered_test_list = {}
+        self.assertEqual(filtered_test_list, filtered_ctest_test_list)
+    
+    def test_list_is_Empty_skip_test(self):
+        self.ctest_test_list = {}
+        self.skip_test='test4'
+        filtered_ctest_test_list = mbed_greentea_cli.create_filtered_test_list(self.ctest_test_list, 
+                                                                               self.test_by_names,
+                                                                               self.skip_test)
+        
+        filtered_test_list = {}
+        self.assertEqual(filtered_test_list, filtered_ctest_test_list)
+    
+    def test_list_is_Empty_test_by_names(self):
+        self.ctest_test_list = {}
+        self.test_by_names='test4'
+        filtered_ctest_test_list = mbed_greentea_cli.create_filtered_test_list(self.ctest_test_list, 
+                                                                               self.test_by_names,
+                                                                               self.skip_test)
+        
+        filtered_test_list = {}
+        self.assertEqual(filtered_test_list, filtered_ctest_test_list)
+            
         
 if __name__ == '__main__':
     unittest.main()

--- a/test/mbed_gt_test_parallel.py
+++ b/test/mbed_gt_test_parallel.py
@@ -136,6 +136,7 @@ class GtOptions:
     def __init__(self,
                  list_of_targets,
                  test_by_names=None,
+                 skip_test=None,
                  only_build_tests=False,
                  skip_yotta_build=True,
                  copy_method=None,
@@ -163,6 +164,7 @@ class GtOptions:
 
         self.list_of_targets = list_of_targets
         self.test_by_names = test_by_names
+        self.skip_test = skip_test
         self.only_build_tests = only_build_tests
         self.skip_yotta_build = skip_yotta_build
         self.copy_method = copy_method


### PR DESCRIPTION
# Description

Added new switch ```--skip-test``` respectively ```-i``` to ignore test cases.
Fixes issue #36 

## Limitations

If you use ```--skip-test``` option with ```--test-by-names``` option, only test_by_names will be applied.

# Usage

Use the option ```-i <test-name>``` to skip a specific test (using name matching). You can use a comma to skip more than one test case. ```<test-name>``` is the name of the test case's binary (without an extension).

## Example
```
$ mbedgt --list
mbedgt: available tests for built targets, location 'C:\Users\stefan.gutmann@arm.com\Documents\GitHub\mbed-drivers\build'
        target 'frdm-k64f-gcc':
        test 'mbed-drivers-test-serial_interrupt'
        test 'mbed-drivers-test-blinky'
        test 'mbed-drivers-test-div'
        test 'mbed-drivers-test-cstring'
        test 'mbed-drivers-test-stdio'
        test 'mbed-drivers-test-stl'
        test 'mbed-drivers-test-rtc'
        test 'mbed-drivers-test-dev_null'
        test 'mbed-drivers-test-cpp'
        test 'mbed-drivers-test-timeout'
        test 'mbed-drivers-test-basic'
        test 'mbed-drivers-test-ticker'
        test 'mbed-drivers-test-ticker_2'
        test 'mbed-drivers-test-heap_and_stack'
        test 'mbed-drivers-test-echo'
        test 'mbed-drivers-test-hello'
        test 'mbed-drivers-test-time_us'
        test 'mbed-drivers-test-sleep_timeout'
        test 'mbed-drivers-test-ticker_3'
        test 'mbed-drivers-test-detect'
```
```
$ mbedgt -t frdm-k64f-gcc -i mbed-drivers-test-cstring,mbed-drivers-test-blinky,mbed-drivers-test-ticker,mbed-drivers-test-ticker_2
mbedgt: detecting connected mbed-enabled devices...
mbedgt: detected 1 device
        detected 'K64F' -> 'K64F[0]', console at 'COM17', mounted at 'E:', target id '0240020152986E5EAF6693E6'
mbedgt: local yotta target search in './yotta_targets' for compatible mbed-target 'k64f'
        inside './yotta_targets\frdm-k64f-gcc' found compatible target 'frdm-k64f-gcc'
mbedgt: processing 'frdm-k64f-gcc' yotta target compatible platforms...
mbedgt: processing 'K64F' platform...
mbedgt: using platform 'K64F' for test:
        target_id_mbed_htm = '0240020152986E5EAF6693E6'
        mount_point = 'E:'
        target_id = '0240020152986E5EAF6693E6'
        serial_port = 'COM17'
        target_id_usb_id = '0240020152986E5EAF6693E6'
        platform_name = 'K64F'
        platform_name_unique = 'K64F[0]'
mbedgt: building your sources and tests with yotta...
        calling yotta: yotta --target=frdm-k64f-gcc,* build
info: generate for target: frdm-k64f-gcc 2.0.0 at C:\Users\stefan.gutmann@arm.com\Documents\GitHub\mbed-drivers\yotta_targets\frdm-k64f-gcc
GCC version is: 4.9.3
-- Configuring done
-- Generating done
-- Build files have been written to: C:/Users/stefan.gutmann@arm.com/Documents/GitHub/mbed-drivers/build/frdm-k64f-gcc
ninja: no work to do.
mbedgt: yotta build for target 'frdm-k64f-gcc' was successful
mbedgt: test case filter (specified with --skip-build option)
        test 'mbed-drivers-test-cstring' skipped
        test 'mbed-drivers-test-blinky' skipped
        test 'mbed-drivers-test-ticker' skipped
        test 'mbed-drivers-test-ticker_2' skipped
mbedgt: running 16 tests for target 'frdm-k64f-gcc' and platform 'K64F'
        use 1 instance for testing
.
.
.
```