### PR TITLE
Notify abort event to mbed-htrun via stdin pipe

### DIFF
--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -182,8 +182,10 @@ def run_host_test(image_path,
                 pass
 
             # Give 5 sec for mbedhtrun to exit
+            ret_code = None
             for i in range(5):
                 ret_code = self.proc.poll()
+                # A None value indicates that the process hasn't terminated yet.
                 if ret_code is not None:
                     break
                 sleep(1)
@@ -194,7 +196,6 @@ def run_host_test(image_path,
                     self.proc.terminate()
                 except Exception as e:
                     print "ProcessObserver.stop(): %s" % str(e)
-                    pass
 
     def get_char_from_queue(obs):
         """ Get character from queue safe way

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -19,7 +19,7 @@ Author: Przemyslaw Wirkus <Przemyslaw.wirkus@arm.com>
 
 import re
 import sys
-from time import time
+from time import time, sleep
 from Queue import Queue, Empty
 from threading import Thread
 from subprocess import call, Popen, PIPE
@@ -174,11 +174,27 @@ def run_host_test(image_path,
 
         def stop(self):
             self.active = False
+
+            # Try stopping mbed-host-test
             try:
-                self.proc.terminate()
-            except Exception as e:
-                print "ProcessObserver.stop(): %s" % str(e)
+                self.proc.stdin.close()
+            finally:
                 pass
+
+            # Give 5 sec for mbedhtrun to exit
+            for i in range(5):
+                ret_code = self.proc.poll()
+                if ret_code is not None:
+                    break
+                sleep(1)
+
+            if ret_code is None:            # Kill it
+                print 'Terminating mbed-host-test(mbedhtrun) process (PID %s)' % self.proc.pid
+                try:
+                    self.proc.terminate()
+                except Exception as e:
+                    print "ProcessObserver.stop(): %s" % str(e)
+                    pass
 
     def get_char_from_queue(obs):
         """ Get character from queue safe way
@@ -256,7 +272,7 @@ def run_host_test(image_path,
         if verbose:
             gt_logger.gt_log_tab("calling mbedhtrun: %s"% " ".join(cmd))
             gt_logger.gt_log("mbed-host-test-runner: started")
-        proc = Popen(cmd, stdout=PIPE)
+        proc = Popen(cmd, stdin=PIPE, stdout=PIPE)
         obs = ProcessObserver(proc)
 
     result = None

--- a/test/mbed_gt_test_parallel.py
+++ b/test/mbed_gt_test_parallel.py
@@ -59,6 +59,7 @@ class TestmbedGt(unittest.TestCase):
 class PopenMock:
     def __init__(self, *args, **kwargs):
         self.stdout = StdOutMock()
+        self.stdin = StdOutMock()
 
     def communicate(self):
         return "_stdout", "_stderr"
@@ -68,6 +69,10 @@ class PopenMock:
 
     def terminate(self):
         pass
+
+    def poll(self):
+        return 0
+    
 
 class StdOutMock:
     def __init__(self):
@@ -98,6 +103,9 @@ HOST: Starting the ECHO test
             time.sleep(uniform(0.1, 2))
             self.offset = 0
             return None
+
+    def close(self):
+        pass
 
 
 def run_host_test_mock(*args, **kwargs):


### PR DESCRIPTION
Fix for issue #48 

For notifying abort event to mbedhtrun stdin pipe is opened while soawning. 
stdin is closed when mbedhtrun is required to be aborted. 
greentea waits for 5 seconds to mbedhtrun to cleanup and exit. If not it terminates mbedhtrun.

mbedhtrun is also updated in PR https://github.com/ARMmbed/htrun/pull/54 to read stdin and exit gracefully when stdin is closed.