### PR TITLE
 Add support for test case id tagging - implementing #66 

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -33,6 +33,7 @@ from mbed_greentea.mbed_test_api import TEST_RESULT_OK
 from mbed_greentea.cmake_handlers import load_ctest_testsuite
 from mbed_greentea.cmake_handlers import list_binaries_for_targets
 from mbed_greentea.mbed_report_api import exporter_text
+from mbed_greentea.mbed_report_api import exporter_testcase_text
 from mbed_greentea.mbed_report_api import exporter_json
 from mbed_greentea.mbed_report_api import exporter_junit
 from mbed_greentea.mbed_target_info import get_mbed_clasic_target_info
@@ -360,25 +361,37 @@ def run_test_thread(test_result_queue, test_queue, opts, mut, mut_info, yotta_ta
                                          enum_host_tests_path=enum_host_tests_path,
                                          verbose=verbose)
 
-        single_test_result, single_test_output, single_testduration, single_timeout = host_test_result
+        single_test_result, single_test_output, single_testduration, single_timeout, result_test_cases = host_test_result
         test_result = single_test_result
         if single_test_result != TEST_RESULT_OK:
             test_exec_retcode += 1
 
         # Update report for optional reporting feature
-        test_name = test['test_bin'].lower()
+        test_suite_name = test['test_bin'].lower()
         if yotta_target_name not in test_report:
             test_report[yotta_target_name] = {}
-        if test_name not in test_report[yotta_target_name]:
-            test_report[yotta_target_name][test_name] = {}
+        if test_suite_name not in test_report[yotta_target_name]:
+            test_report[yotta_target_name][test_suite_name] = {}
 
-        test_report[yotta_target_name][test_name]['single_test_result'] = single_test_result
-        test_report[yotta_target_name][test_name]['single_test_output'] = single_test_output
-        test_report[yotta_target_name][test_name]['elapsed_time'] = single_testduration
-        test_report[yotta_target_name][test_name]['platform_name'] = micro
-        test_report[yotta_target_name][test_name]['copy_method'] = copy_method
+        test_report[yotta_target_name][test_suite_name]['single_test_result'] = single_test_result
+        test_report[yotta_target_name][test_suite_name]['single_test_output'] = single_test_output
+        test_report[yotta_target_name][test_suite_name]['elapsed_time'] = single_testduration
+        test_report[yotta_target_name][test_suite_name]['platform_name'] = micro
+        test_report[yotta_target_name][test_suite_name]['copy_method'] = copy_method
+        test_report[yotta_target_name][test_suite_name]['copy_method'] = copy_method
+        test_report[yotta_target_name][test_suite_name]['testcase_result'] = result_test_cases
 
-        gt_logger.gt_log("test on hardware with target id: %s \n\ttest '%s' %s %s in %.2f sec"% (mut['target_id'], test['test_bin'], '.' * (80 - len(test['test_bin'])), test_result, single_testduration))
+        gt_logger.gt_log("test on hardware with target id: %s"% (mut['target_id']))
+        gt_logger.gt_log("test suite '%s' %s %s in %.2f sec"% (test['test_bin'],
+            '.' * (80 - len(test['test_bin'])),
+            test_result,
+            single_testduration))
+
+        for tc_name in sorted(result_test_cases.keys()):
+            gt_logger.gt_log_tab("test case '%s' %s %s in %.2f sec"% (tc_name,
+                '.' * (81 - len(tc_name)),
+                result_test_cases[tc_name]['result_text'],
+                result_test_cases[tc_name]['duration']))
 
         if single_test_result != 'OK' and not verbose and opts.report_fails:
             # In some cases we want to print console to see why test failed
@@ -430,7 +443,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
                                          enum_host_tests_path=enum_host_tests_path,
                                          verbose=opts.verbose_test_result_only)
 
-        single_test_result, single_test_output, single_testduration, single_timeout = host_test_result
+        single_test_result, single_test_output, single_testduration, single_timeout, result_test_cases = host_test_result
         status = TEST_RESULTS.index(single_test_result) if single_test_result in TEST_RESULTS else -1
         return (status)
 
@@ -625,7 +638,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
                                                      enum_host_tests_path=enum_host_tests_path,
                                                      verbose=True)
 
-                    single_test_result, single_test_output, single_testduration, single_timeout = host_test_result
+                    single_test_result, single_test_output, single_testduration, single_timeout, result_test_cases = host_test_result
                     status = TEST_RESULTS.index(single_test_result) if single_test_result in TEST_RESULTS else -1
                     if single_test_result != TEST_RESULT_OK:
                         test_exec_retcode += 1
@@ -716,11 +729,12 @@ def main_cli(opts, args, gt_instance_uuid=None):
     if not opts.only_build_tests:
         # Reports (to file)
         if opts.report_junit_file_name:
+            gt_logger.gt_log("exporting to JUnit file '%s'..."% gt_logger.gt_bright(opts.report_junit_file_name))
             junit_report = exporter_junit(test_report)
             with open(opts.report_junit_file_name, 'w') as f:
                 f.write(junit_report)
         if opts.report_text_file_name:
-            gt_logger.gt_log("exporting to junit '%s'..."% gt_logger.gt_bright(opts.report_text_file_name))
+            gt_logger.gt_log("exporting to file '%s'..."% gt_logger.gt_bright(opts.report_text_file_name))
             text_report, text_results = exporter_text(test_report)
             with open(opts.report_text_file_name, 'w') as f:
                 f.write(text_report)
@@ -733,10 +747,16 @@ def main_cli(opts, args, gt_instance_uuid=None):
         else:
             # Final summary
             if test_report:
-                gt_logger.gt_log("test report:")
+                # Test suite report
+                gt_logger.gt_log("test suite report:")
                 text_report, text_results = exporter_text(test_report)
                 print text_report
-                gt_logger.gt_log("results: " + text_results)
+                gt_logger.gt_log("test suite results: " + text_results)
+                # test case detailed report
+                gt_logger.gt_log("test case report:")
+                text_testcase_report, text_testcase_results = exporter_testcase_text(test_report)
+                print text_testcase_report
+                gt_logger.gt_log("test case results: " + text_testcase_results)
 
         # This flag guards 'build only' so we expect only yotta errors
         if test_platforms_match == 0:

--- a/mbed_greentea/mbed_report_api.py
+++ b/mbed_greentea/mbed_report_api.py
@@ -18,6 +18,21 @@ Author: Przemyslaw Wirkus <Przemyslaw.wirkus@arm.com>
 """
 
 
+def export_to_file(file_name, payload):
+    """! Simple file dump used to store reports on disk
+    @param file_name Report file name (with path if needed)
+    @param payload Data to store inside file
+    @return True if report save was successful
+    """
+    result = True
+    try:
+        with open(file_name, 'w') as f:
+            f.write(payload)
+    except IOError as e:
+        print "Exporting report to file failed: ", str(e)
+        result = False
+    return result
+
 def exporter_junit(test_result_ext, test_suite_properties=None):
     """! Export test results in JUnit XML compliant format
     @details This function will import junit_xml library to perform report conversion
@@ -69,13 +84,13 @@ def exporter_text(test_result_ext, test_suite_properties=None):
     """
     from prettytable import PrettyTable
     #TODO: export to text, preferably to PrettyTable (SQL like) format
-    cols = ['target', 'platform_name', 'test', 'result', 'elapsed_time (sec)', 'copy_method']
+    cols = ['target', 'platform_name', 'test suite', 'result', 'elapsed_time (sec)', 'copy_method']
     pt = PrettyTable(cols)
     for col in cols:
         pt.align[col] = "l"
     pt.padding_width = 1 # One space between column edges and contents (default)
 
-    result_dict = {}    # Used to print mbed 2.0 test result like short summary
+    result_dict = {}            # Used to print test suite results
 
     for target_name in test_result_ext:
         test_results = test_result_ext[target_name]
@@ -100,4 +115,60 @@ def exporter_text(test_result_ext, test_suite_properties=None):
 
     result_pt = pt.get_string()
     result_res = ' / '.join(['%s %s' % (value, key) for (key, value) in {k: v for k, v in result_dict.items() if v != 0}.iteritems()])
+    return result_pt, result_res
+
+def exporter_testcase_text(test_result_ext, test_suite_properties=None):
+    """! Exports test case results to text formatted output
+    @details This is a human friendly format
+    @return Tuple with table of results and result quantity summary string
+    """
+    from prettytable import PrettyTable
+    #TODO: export to text, preferably to PrettyTable (SQL like) format
+    cols = ['target', 'platform_name', 'test suite', 'test case', 'result', 'elapsed_time (sec)', 'copy_method']
+    pt = PrettyTable(cols)
+    for col in cols:
+        pt.align[col] = "l"
+    pt.padding_width = 1 # One space between column edges and contents (default)
+
+    result_testcase_dict = {}   # Used to print test case results
+
+    for target_name in test_result_ext:
+        test_results = test_result_ext[target_name]
+        row = []
+        for test_suite_name in test_results:
+            test = test_results[test_suite_name]
+
+            # testcase_result stores info about test case results
+            testcase_result = test['testcase_result']
+            #   "testcase_result": {
+            #       "STRINGS004": {
+            #           "duration": 0.009999990463256836,
+            #           "time_start": 1453073018.275,
+            #           "time_end": 1453073018.285,
+            #           "result": 1
+            #       },
+
+            for tc_name in sorted(testcase_result.keys()):
+                duration = testcase_result[tc_name]['duration']
+                result = int(testcase_result[tc_name]['result'])
+                result_text = testcase_result[tc_name]['result_text']
+
+                # Grab quantity of each test result
+                if result_text in result_testcase_dict:
+                    result_testcase_dict[result_text] += 1
+                else:
+                    result_testcase_dict[result_text] = 1
+
+                row.append(target_name)
+                row.append(test['platform_name'])
+                row.append(test_suite_name)
+                row.append(tc_name)
+                row.append(result_text)
+                row.append(round(duration, 2))
+                row.append(test['copy_method'])
+                pt.add_row(row)
+                row = []
+
+    result_pt = pt.get_string()
+    result_res = ' / '.join(['%s %s' % (value, key) for (key, value) in {k: v for k, v in result_testcase_dict.items() if v != 0}.iteritems()])
     return result_pt, result_res


### PR DESCRIPTION
** This is conceptual implementation, to understand better test case functionality **

This PR is an implementation part of  #66: "Add support for test case id tagging".
We want to add more detailed test case results from tests (binaries being run).

We want to move to official name of:
* *Test suite* for binary running set of test cases. TS name will be a binary name biult by yotta.
* *Test case* / *Test Case Id* is a part of TS and can return an success code: ```OK```, ```FAIL```, ```ERROR```.