### PR TITLE
Shuffle test execution order

### DIFF
--- a/mbed_greentea/cmake_handlers.py
+++ b/mbed_greentea/cmake_handlers.py
@@ -98,7 +98,7 @@ def list_binaries_for_targets(build_dir='./build', verbose_footer=False):
             test_list = load_ctest_testsuite(sub_dir, binary_type='')
             if len(test_list):
                 gt_logger.gt_log_tab("target '%s':" % sub_dir.split(os.sep)[-1])
-                for test in test_list:
+                for test in sorted(test_list):
                     gt_logger.gt_log_tab("test '%s'"% test)
     else:
         gt_logger.gt_log_warn("no tests found in current location")

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -571,11 +571,13 @@ def main_cli(opts, args, gt_instance_uuid=None):
         gt_logger.gt_log_err("argument of mode --parallel is not a int, disable parallel mode")
         parallel_test_exec = 1
 
-    # Values uised to generate random seed for test order shuffle
-    shuffle_random_seed = 0.0
-    SHUFFLE_SEED_ROUND = 10
-
+    # Values used to generate random seed for test execution order shuffle
+    SHUFFLE_SEED_ROUND = 10 # Value used to round float random seed
     shuffle_random_seed = round(random.random(), SHUFFLE_SEED_ROUND)
+
+    # Set shuffle seed if it is provided with command line option
+    if opts.shuffle_test_seed:
+        shuffle_random_seed = round(float(opts.shuffle_test_seed), SHUFFLE_SEED_ROUND)
 
     ### Testing procedures, for each target, for each target's compatible platform
     for yotta_target_name in yt_target_platform_map:
@@ -684,6 +686,8 @@ def main_cli(opts, args, gt_instance_uuid=None):
                     gt_logger.gt_bright(platform_name)
                 ))
 
+                # Test execution order can be shuffled (also with provided random seed)
+                # for test execution reproduction.
                 filtered_ctest_test_list_keys = filtered_ctest_test_list.keys()
                 if opts.shuffle_test_order:
                     # We want to shuffle test names randomly

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -115,7 +115,7 @@ def create_filtered_test_list(ctest_test_list, test_by_names, skip_test):
                 del filtered_ctest_test_list[test_name]
 
     if invalid_test_names:
-        opt_to_print = '-n' if test_by_names else 'skip-build'
+        opt_to_print = '-n' if test_by_names else 'skip-test'
         gt_logger.gt_log_warn("invalid test case names (specified with '%s' option)"% opt_to_print)
         for test_name in invalid_test_names:
             gt_logger.gt_log_warn("test name '%s' not found in CTestTestFile.cmake (specified with '%s' option)"% (gt_logger.gt_bright(test_name),opt_to_print))

--- a/mbed_greentea/mbed_report_api.py
+++ b/mbed_greentea/mbed_report_api.py
@@ -77,10 +77,10 @@ def exporter_text(test_result_ext, test_suite_properties=None):
 
     result_dict = {}    # Used to print mbed 2.0 test result like short summary
 
-    for target_name in test_result_ext:
+    for target_name in sorted(test_result_ext):
         test_results = test_result_ext[target_name]
         row = []
-        for test_name in test_results:
+        for test_name in sorted(test_results):
             test = test_results[test_name]
 
             # Grab quantity of each test result

--- a/test/mbed_gt_test_parallel.py
+++ b/test/mbed_gt_test_parallel.py
@@ -72,7 +72,7 @@ class PopenMock:
 
     def poll(self):
         return 0
-    
+
 
 class StdOutMock:
     def __init__(self):
@@ -167,6 +167,8 @@ class GtOptions:
                  enum_host_tests=None,
                  yotta_search_for_mbed_target=False,
                  plain=False,
+                 shuffle_test_order=False,
+                 shuffle_test_seed=None,
                  verbose=True,
                  version=False):
 
@@ -195,6 +197,8 @@ class GtOptions:
         self.enum_host_tests = enum_host_tests
         self.yotta_search_for_mbed_target = yotta_search_for_mbed_target
         self.plain = plain
+        self.shuffle_test_order = shuffle_test_order
+        self.shuffle_test_seed = shuffle_test_seed
         self.verbose = verbose
         self.version = version
 


### PR DESCRIPTION
# Description
* Adds test case execution order shuffle:
  * ```-u```, ```--shuffle``` flag used to randomly shuffle test execution.
  * ```--shuffle-seed <float>``` - flag used to pass custom shuffle seed. Note: ```<float>```: should be in ```[0, 1)```.
  * Greentea prints current shuffle seed in log:
```
mbedgt: shuffle seed: 0.1806805564
```
Value ```0.1806805564``` can be used with ```--shuffle-seed``` to order test case execution the same way in future run.
Note: If you shuffle different number of tests even seed is the same test order will be different. So please shuffle with seed the same list of tests!
* Implements https://github.com/ARMmbed/greentea/issues/68.
  * Text test report summary sorted by target name and test name.
  * List from ```--list``` sorted by test name.

# Shuffle test execution order
* Execute all yotta module tests in **default** order:
```
$ mbedgt -V
mbedgt: test on hardware with target id: 02400226489a1e6c000000000000000000000000b543e3d4
        test 'mbed-drivers-test-cstring' ....................................................... FAIL in 2.92 sec
mbedgt: test on hardware with target id: 02400226489a1e6c000000000000000000000000b543e3d4
        test 'mbed-drivers-test-basic' ......................................................... OK in 2.38 sec
mbedgt: test on hardware with target id: 02400226489a1e6c000000000000000000000000b543e3d4
        test 'mbed-drivers-test-stl' ........................................................... OK in 2.88 sec
```
Note: Tests are executed in order: *mbed-drivers-test-cstring*, *mbed-drivers-test-basic*, *mbed-drivers-test-stl*

* Execute all yotta module tests in **random** order:
```
$ mbedgt -V -u
...
mbedgt: test on hardware with target id: 02400226489a1e6c000000000000000000000000b543e3d4
        test 'mbed-drivers-test-stl' ........................................................... OK in 3.04 sec
mbedgt: test on hardware with target id: 02400226489a1e6c000000000000000000000000b543e3d4
        test 'mbed-drivers-test-basic' ......................................................... OK in 2.40 sec
mbedgt: test on hardware with target id: 02400226489a1e6c000000000000000000000000b543e3d4
        test 'mbed-drivers-test-cstring' ....................................................... FAIL in 2.97 sec
mbedgt: shuffle seed: 0.1806805564
...
```

Note: Tests are executed in order: *mbed-drivers-test-stl*, *mbed-drivers-test-basic*, *mbed-drivers-test-cstring*.

* Execute all yotta module tests in the same order as above:
```
$ mbedgt -V -u --shuffle-seed 0.1806805564
...
mbedgt: test on hardware with target id: 02400226489a1e6c000000000000000000000000b543e3d4
        test 'mbed-drivers-test-stl' ........................................................... OK in 3.04 sec
mbedgt: test on hardware with target id: 02400226489a1e6c000000000000000000000000b543e3d4
        test 'mbed-drivers-test-basic' ......................................................... OK in 2.40 sec
mbedgt: test on hardware with target id: 02400226489a1e6c000000000000000000000000b543e3d4
        test 'mbed-drivers-test-cstring' ....................................................... FAIL in 2.97 sec
mbedgt: shuffle seed: 0.1806805564
...
```
Note: Tests are executed in order: *mbed-drivers-test-stl*, *mbed-drivers-test-basic*, *mbed-drivers-test-cstring*.

**Note**: Test reports are ALWAYS sorted by target name and test name so test report always appears in sorted order and doesn't reflect shuffle soft.
