### PR TITLE
greentea should only end a test when ^{{end}}$ is received. Issue 70

### DIFF
--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -324,8 +324,9 @@ def run_host_test(image_path,
                     output.append('{{mbed_assert}}')
                     break
 
-                # Check for test end
-                if '{end}' in line:
+                # Check for test end. Only a '{{end}}' in the start of line indicates a test end.
+                # A sub string '{{end}}' may also appear in an error message.
+                if re.search('^\{\{end\}\}', line, re.I):
                     break
                 line = ''
             else:


### PR DESCRIPTION
Fix for issue #70 

Currently greentea terminates a test when {{end}} is read on stdout of mbedhtrun. Even if it is part of an error message. Like: HOST: Unknown test property print format: {{end}}

Originally issue was reported on mbedhtrun ARMmbed/htrun#44. Please this issue for steps to reproduce.