### PR TITLE
add arch_ble target from seeed

### DIFF
--- a/mbed_greentea/mbed_target_info.py
+++ b/mbed_greentea/mbed_target_info.py
@@ -92,6 +92,20 @@ TARGET_INFO_MAPPING = {
                 "reset_method": "default",
                 "program_cycle_s": 4
             }
+        },
+    "ARCH_BLE" : {
+        "yotta_targets": [
+                {
+                    "yotta_target": "tinyble-gcc",
+                    "mbed_toolchain": "GCC_ARM"
+                }
+             ],
+        "properties" : {
+                "binary_type": "-combined.hex",
+                "copy_method": "shell",
+                "reset_method": "default",
+                "program_cycle_s": 4
+            }
         }
 }
 


### PR DESCRIPTION
I found that tests were failing because greentea wasnt using the -combined.hex file with merged softdevice.
https://github.com/ARMmbed/mbed-drivers/issues/143

My seeed firmware reports target arch_ble which is an nrf51822 variant which is hardcoded here. 

It might be better to encode this information into the target instead?