### PR TITLE
Saving gcov .gcda files with relative path.

### DIFF
--- a/mbed_greentea/mbed_coverage_api.py
+++ b/mbed_greentea/mbed_coverage_api.py
@@ -46,7 +46,8 @@ def coverage_pack_hex_payload(payload):
     bin_payload = bytearray([int(s, 16) for s in hex_pairs])
     return bin_payload
 
-def coverage_dump_file(path, payload):
+
+def coverage_dump_file(yotta_target, path, payload):
     """! Creates file and dumps payload to it on specified path (even if path doesn't exist)
     @param path Path to file
     @param payload Binary data to store in a file
@@ -54,7 +55,11 @@ def coverage_dump_file(path, payload):
     """
     result = True
     try:
-        d = os.path.dirname(path)
+        d, filename = os.path.split(path)
+        if not os.path.isabs(d) and not os.path.exists(d):
+            # For a relative path that do not exist. Try adding ./build/<yotta target> prefix
+            d = os.path.join('build', yotta_target, d)
+            path = os.path.join(d, filename)
         if not os.path.exists(d):
             os.makedirs(d)
         with open(path, "wb") as f:

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -550,9 +550,10 @@ def main_cli(opts, args, gt_instance_uuid=None):
     # Capture alternative test console inputs, used e.g. in 'yotta test command'
     if opts.digest_source:
         enum_host_tests_path = get_local_host_tests_dir(opts.enum_host_tests)
-        host_test_result = run_host_test(image_path=None,
-                                         disk=None,
-                                         port=None,
+        host_test_result = run_host_test(None,
+                                         None,
+                                         None,
+                                         None,
                                          hooks=greentea_hooks,
                                          digest_source=opts.digest_source,
                                          enum_host_tests_path=enum_host_tests_path,
@@ -755,6 +756,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
                     host_test_result = run_host_test(opts.run_app,
                                                      disk,
                                                      port,
+                                                     yotta_target_name,
                                                      micro=micro,
                                                      copy_method=copy_method,
                                                      program_cycle_s=program_cycle_s,

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -371,6 +371,7 @@ def run_test_thread(test_result_queue, test_queue, opts, mut, mut_info, yotta_ta
         host_test_result = run_host_test(test['image_path'],
                                          disk,
                                          port,
+                                         yotta_target_name,
                                          micro=micro,
                                          copy_method=copy_method,
                                          program_cycle_s=program_cycle_s,

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -87,6 +87,7 @@ def get_test_result(output):
 def run_host_test(image_path,
                   disk,
                   port,
+                  yotta_target,
                   duration=10,
                   micro=None,
                   reset=None,
@@ -190,7 +191,7 @@ def run_host_test(image_path,
     result = get_test_result(htrun_output)
     result_test_cases = get_testcase_result(htrun_output)
     test_cases_summary = get_testcase_summary(htrun_output)
-    get_coverage_data(htrun_output)
+    get_coverage_data(yotta_target, htrun_output)
 
     if verbose:
         gt_logger.gt_log("mbed-host-test-runner: stopped")
@@ -237,7 +238,7 @@ def get_testcase_utest(output, test_case_name):
 
     return tc_log_lines
 
-def get_coverage_data(output):
+def get_coverage_data(yotta_target, output):
     # Example GCOV output
     # [1456840876.73][CONN][RXD] {{__coverage_start;c:\Work\core-util/source/PoolAllocator.cpp.gcda;6164636772393034c2733f32...a33e...b9}}
     gt_logger.gt_log("checking for GCOV data...")
@@ -248,7 +249,7 @@ def get_coverage_data(output):
             timestamp, _, gcov_path, gcov_payload = m.groups()
             try:
                 bin_gcov_payload = coverage_pack_hex_payload(gcov_payload)
-                coverage_dump_file(gcov_path, bin_gcov_payload)
+                coverage_dump_file(yotta_target, gcov_path, bin_gcov_payload)
             except Exception as e:
                 gt_logger.gt_log_err("error while handling GCOV data: " + str(e))
             gt_logger.gt_log_tab("storing %d bytes in '%s'"% (len(bin_gcov_payload), gcov_path))


### PR DESCRIPTION
If mbed target is compiled with ```-fprofile-dir=.``` it will print .gcda file paths relative to ```./build/<yotta target>```. Changes here are to save these files with a prefix ```./build/<yotta target>```.