### PR TITLE
Add greentea-client dependency detection

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -565,7 +565,18 @@ def main_cli(opts, args, gt_instance_uuid=None):
     ### Read yotta module basic information
     yotta_module = YottaModule()
     yotta_module.init() # Read actual yotta module data
-
+    
+    # Check if greentea-client is in module.json of repo to test, otherwise abort
+    if not yotta_module.check_greentea_client():
+        gt_logger.gt_log("""
+        *****************************************************************************************
+        * Please downgrade to Greentea before v0.2.0: pip install mbed-greentea<0.2.0 --upgrade *
+        * or                                                                                    *
+        * port your tests to new async model: https://github.com/ARMmbed/greentea/pull/78       *
+        *****************************************************************************************
+        """)
+        return (0)
+        
     ### Selecting yotta targets to process
     yt_targets = [] # List of yotta targets specified by user used to process during this run
     if opts.list_of_targets:

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -566,13 +566,19 @@ def main_cli(opts, args, gt_instance_uuid=None):
     yotta_module = YottaModule()
     yotta_module.init() # Read actual yotta module data
     
-    # Check if greentea-client is in module.json of repo to test, otherwise abort
+    # Check if NO greentea-client is in module.json of repo to test, if so abort
     if not yotta_module.check_greentea_client():
         gt_logger.gt_log("""
         *****************************************************************************************
-        * Please downgrade to Greentea before v0.2.0: pip install mbed-greentea<0.2.0 --upgrade *
-        * or                                                                                    *
-        * port your tests to new async model: https://github.com/ARMmbed/greentea/pull/78       *
+        * We've noticed that NO 'greentea-client' module is specified in                        *
+        * dependency/testDependency section of this module's 'module.json' file.                *
+        *                                                                                       *
+        * This version of Greentea requires 'greentea-client' module.                           *
+        * Please downgrade to Greentea before v0.2.0:                                           *
+        *                                                                                       *
+        * $ pip install "mbed-greentea<0.2.0" --upgrade                                         *
+        *                                                                                       *
+        * or port your tests to new Async model: https://github.com/ARMmbed/greentea/pull/78    *
         *****************************************************************************************
         """)
         return (0)

--- a/mbed_greentea/mbed_yotta_module_parse.py
+++ b/mbed_greentea/mbed_yotta_module_parse.py
@@ -108,3 +108,14 @@ class YottaModule():
 
     def get_name(self):
         return self.__yotta_module.get('name', 'unknown')
+        
+    def check_greentea_client(self):
+        dependencies = self.__yotta_module.get('dependencies', False)
+        testDependencies = self.__yotta_module.get('testDependencies', False)
+        if dependencies:
+            if dependencies.get('greentea-client', False):
+                return True
+        if testDependencies:
+            if testDependencies.get('greentea-client', False):
+                return True
+        return False

--- a/test/mbed_gt_yotta_module.py
+++ b/test/mbed_gt_yotta_module.py
@@ -65,6 +65,9 @@ class YOttaConfigurationParse(unittest.TestCase):
     def test_get_dict_items(self):
         self.assertEqual('Simple test harness with unity and greentea integration.', self.yotta_module.get_data().get('description'))
         self.assertEqual('Apache-2.0', self.yotta_module.get_data().get('license'))
+        
+    def test_check_greentea_client(self):
+        self.assertTrue(self.yotta_module.check_greentea_client())
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# Description

Added detection of greentea-client dependency. Print warning if greentea-client is not in dependencies and abort test.

Fixes issue #84 

## Example
Example shows console output if greentea-client is not specified.
```
$ mbedgt -VS
mbedgt:
        *****************************************************************************************
        * We've noticed that NO 'greentea-client' module is specified in                        *
        * dependency/testDependency section of this module's 'module.json' file.                *
        *                                                                                       *
        * This version of Greentea requires 'greentea-client' module.                           *
        * Please downgrade to Greentea before v0.2.0:                                           *
        *                                                                                       *
        * $ pip install "mbed-greentea<0.2.0" --upgrade                                         *
        *                                                                                       *
        * or port your tests to new Async model: https://github.com/ARMmbed/greentea/pull/78    *
        *****************************************************************************************

mbedgt: completed in 0.00 sec
```