### PR TITLE
[master_v0_1_x] Add greentea-client dependency detection

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -461,7 +461,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
         * This version of Greentea doesn't support 'greentea-client' module.                    *
         * Please uprade to Greentea after v0.2.0:                                               *
         *                                                                                       *
-        * $ pip install mbed-greentea>=0.2.0 --upgrade                                          *
+        * $ pip install "mbed-greentea>=0.2.0" --upgrade                                          *
         *****************************************************************************************
         """)
         return (0)

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -461,7 +461,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
         * This version of Greentea doesn't support 'greentea-client' module.                    *
         * Please uprade to Greentea after v0.2.0:                                               *
         *                                                                                       *
-        * $ pip install "mbed-greentea>=0.2.0" --upgrade                                          *
+        * $ pip install "mbed-greentea>=0.2.0" --upgrade                                        *
         *****************************************************************************************
         """)
         return (0)

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -44,7 +44,8 @@ from mbed_greentea.mbed_greentea_dlm import greentea_get_app_sem
 from mbed_greentea.mbed_greentea_dlm import greentea_update_kettle
 from mbed_greentea.mbed_greentea_dlm import greentea_clean_kettle
 from mbed_greentea.mbed_yotta_api import build_with_yotta
-from mbed_greentea.mbed_yotta_target_parse import YottaConfig
+from mbed_greentea.mbed_yotta_module_parse import YottaConfig
+from mbed_greentea.mbed_yotta_module_parse import YottaModule
 
 try:
     import mbed_lstools
@@ -445,7 +446,26 @@ def main_cli(opts, args, gt_instance_uuid=None):
         single_test_result, single_test_output, single_testduration, single_timeout = host_test_result
         status = TEST_RESULTS.index(single_test_result) if single_test_result in TEST_RESULTS else -1
         return (status)
+        
+    ### Read yotta module basic information
+    yotta_module = YottaModule()
+    yotta_module.init() # Read actual yotta module data
 
+    # Check if greentea-client is in module.json of repo to test, if so abort
+    if yotta_module.check_greentea_client():
+        gt_logger.gt_log("""
+        *****************************************************************************************
+        * We've noticed that 'greentea-client' module is specified in dependency/testDependency *
+        * section of this module's 'module.json' file.                                          *
+        *                                                                                       *
+        * This version of Greentea doesn't support 'greentea-client' module.                    *
+        * Please uprade to Greentea after v0.2.0:                                               *
+        *                                                                                       *
+        * $ pip install mbed-greentea>=0.2.0 --upgrade                                          *
+        *****************************************************************************************
+        """)
+        return (0)
+          
     ### Selecting yotta targets to process
     yt_targets = [] # List of yotta targets specified by user used to process during this run
     if opts.list_of_targets:

--- a/mbed_greentea/mbed_yotta_module_parse.py
+++ b/mbed_greentea/mbed_yotta_module_parse.py
@@ -1,6 +1,6 @@
 """
 mbed SDK
-Copyright (c) 2011-2015 ARM Limited
+Copyright (c) 2011-2016 ARM Limited
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -77,3 +77,45 @@ class YottaConfig():
             if 'test-pins' in self.yotta_config['hardware']:
                 return self.yotta_config['hardware']['test-pins']
         return None
+
+
+class YottaModule():
+
+    __yotta_module = None
+
+    def __init__(self):
+        self.MODULE_PATH = '.'
+        self.YOTTA_CONFIG_NAME = 'module.json'
+
+    def init(self):
+        """! Loads yotta_module.json as an object from local yotta build directory
+        @return True if data was successfuly loaded from the file
+        """
+        try:
+            path = os.path.join(self.MODULE_PATH, self.YOTTA_CONFIG_NAME)
+            with open(path, 'r') as data_file:
+                self.__yotta_module = json.load(data_file)
+        except IOError as e:
+            print "YottaModule: error - ", str(e)
+            self.__yotta_module = {}
+        return bool(len(self.__yotta_module))
+
+    def set_yotta_module(self, yotta_module):
+        self.__yotta_module = yotta_module
+
+    def get_data(self):
+        return self.__yotta_module
+
+    def get_name(self):
+        return self.__yotta_module.get('name', 'unknown')
+        
+    def check_greentea_client(self):
+        dependencies = self.__yotta_module.get('dependencies', False)
+        testDependencies = self.__yotta_module.get('testDependencies', False)
+        if dependencies:
+            if dependencies.get('greentea-client', False):
+                return True
+        if testDependencies:
+            if testDependencies.get('greentea-client', False):
+                return True
+        return False

--- a/test/mbed_gt_yotta_config.py
+++ b/test/mbed_gt_yotta_config.py
@@ -17,7 +17,7 @@ limitations under the License.
 """
 
 import unittest
-from mbed_greentea.mbed_yotta_target_parse import YottaConfig
+from mbed_greentea.mbed_yotta_module_parse import YottaConfig
 
 class YOttaConfigurationParse(unittest.TestCase):
 

--- a/test/mbed_gt_yotta_module.py
+++ b/test/mbed_gt_yotta_module.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+"""
+mbed SDK
+Copyright (c) 2011-2015 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+from mbed_greentea.mbed_yotta_module_parse import YottaModule
+
+
+class YOttaConfigurationParse(unittest.TestCase):
+
+    def setUp(self):
+        self.YOTTA_MODULE_LONG = {
+            "name": "utest",
+            "version": "1.9.1",
+            "description": "Simple test harness with unity and greentea integration.",
+            "keywords": [
+                "greentea",
+                "testing",
+                "unittest",
+                "unity",
+                "unit",
+                "test",
+                "asynchronous",
+                "async",
+                "mbed-official"
+                ],
+            "author": "Niklas Hauser <niklas.hauser@arm.com>",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "minar": "^1.0.0",
+                "core-util": "^1.0.1",
+                "compiler-polyfill": "^1.2.0",
+                "mbed-drivers": "~0.12.0",
+                "greentea-client": "^0.1.2"
+                },
+            "testDependencies": {
+                "unity": "^2.0.1",
+                "greentea-client": "^0.1.2"
+                }
+        }
+
+        self.yotta_module = YottaModule()
+        self.yotta_module.set_yotta_module(self.YOTTA_MODULE_LONG)
+
+    def tearDown(self):
+        pass
+
+    def test_get_name(self):
+        self.assertEqual('utest', self.yotta_module.get_name())
+
+    def test_get_dict_items(self):
+        self.assertEqual('Simple test harness with unity and greentea integration.', self.yotta_module.get_data().get('description'))
+        self.assertEqual('Apache-2.0', self.yotta_module.get_data().get('license'))
+        
+    def test_check_greentea_client(self):
+        self.assertTrue(self.yotta_module.check_greentea_client())
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/mbed_gt_yotta_module.py
+++ b/test/mbed_gt_yotta_module.py
@@ -44,12 +44,10 @@ class YOttaConfigurationParse(unittest.TestCase):
                 "minar": "^1.0.0",
                 "core-util": "^1.0.1",
                 "compiler-polyfill": "^1.2.0",
-                "mbed-drivers": "~0.12.0",
-                "greentea-client": "^0.1.2"
+                "mbed-drivers": "~0.12.0"
                 },
             "testDependencies": {
-                "unity": "^2.0.1",
-                "greentea-client": "^0.1.2"
+                "unity": "^2.0.1"
                 }
         }
 
@@ -67,7 +65,7 @@ class YOttaConfigurationParse(unittest.TestCase):
         self.assertEqual('Apache-2.0', self.yotta_module.get_data().get('license'))
         
     def test_check_greentea_client(self):
-        self.assertTrue(self.yotta_module.check_greentea_client())
+        self.assertFalse(self.yotta_module.check_greentea_client())
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# Description

Added detection of greentea-client dependency. Print warning if greentea-client is in dependencies and abort test.

Fixes issue #84 

## Example
Example shows console output if greentea-client is not specified.
```
$ mbedgt 
mbedgt:
        *****************************************************************************************
        * We've noticed that 'greentea-client' module is specified in dependency/testDependency *
        * section of this module's 'module.json' file.                                          *
        *                                                                                       *
        * This version of Greentea doesn't support 'greentea-client' module.                    *
        * Please uprade to Greentea after v0.2.0:                                               *
        *                                                                                       *
        * $ pip install "mbed-greentea>=0.2.0" --upgrade                                        *
        *****************************************************************************************

mbedgt: completed in 0.01 sec
```
```
$ pip install "mbed-greentea>=0.2.0" --upgrade 
...  
$ mbedgt --version
0.2.2

$ mbedhtrun --version
0.2.1
```
