### PR TITLE
Add try/catch around encoding for JUNIT stdout/stderr

### DIFF
--- a/mbed_greentea/mbed_report_api.py
+++ b/mbed_greentea/mbed_report_api.py
@@ -200,7 +200,10 @@ def exporter_testcase_junit(test_result_ext, test_suite_properties=None):
 
             # tc_elapsed_sec = test['elapsed_time']
             tc_stdout = ''  #test['single_test_output']
-            tc_stderr = test['single_test_output'].decode('unicode_escape').encode('ascii','ignore')
+            try:
+                tc_stderr = test['single_test_output'].decode('unicode_escape').encode('ascii','ignore')
+            except UnicodeDecodeError as e:
+                print "exporter_testcase_junit:", str(e)
 
             # testcase_result stores info about test case results
             testcase_result = test['testcase_result']
@@ -222,7 +225,11 @@ def exporter_testcase_junit(test_result_ext, test_suite_properties=None):
                 utest_log = testcase_result[tc_name].get('utest_log', '')
                 result_text = testcase_result[tc_name].get('result_text', "UNDEF")
 
-                tc_stdout = '\n'.join(utest_log).decode('unicode_escape').encode('ascii','ignore')
+                try:
+                    tc_stdout = '\n'.join(utest_log).decode('unicode_escape').encode('ascii','ignore')
+                except UnicodeDecodeError as e:
+                    print "exporter_testcase_junit:", str(e)
+
                 tc_class = ym_name + '.' + target_name + '.' + test_suite_name
                 tc = TestCase(tc_name, tc_class, duration, tc_stdout, tc_stderr)
 


### PR DESCRIPTION
This PR fixes #87.

# Description
When storing Junit result we encode certain characters so they can be dumped to Junit XML report.
Currently we will just ignore all non-ascii characters, it the future we might add additional non-ascii / user friendly binary data dump.

# Issue 87 traceback:
```python
Traceback (most recent call last):
  File "C:\jslv3_2\ws\gtt\venv\Scripts\mbedgt-script.py", line 9, in <module>
    load_entry_point('mbed-greentea', 'console_scripts', 'mbedgt')()
  File "c:\jslv3_2\ws\gtt\venv\src\mbed-greentea\mbed_greentea\mbed_greentea_cli.py", line 315, in main
    cli_ret = main_cli(opts, args)
  File "c:\jslv3_2\ws\gtt\venv\src\mbed-greentea\mbed_greentea\mbed_greentea_cli.py", line 842, in main_cli
    junit_report = exporter_testcase_junit(test_report, test_suite_properties=yotta_module.get_data())
  File "c:\jslv3_2\ws\gtt\venv\src\mbed-greentea\mbed_greentea\mbed_report_api.py", line 203, in exporter_testcase_junit
    tc_stderr = test['single_test_output'].decode('unicode_escape').encode('ascii','ignore')
UnicodeDecodeError: 'unicodeescape' codec can't decode bytes in position 25420-25421: truncated \UXXXXXXXX escape
```

# New notifications
After we apply this fix we will add new prints (```exporter_testcase_junit```) to notify users we've shaped Junit output:
```
$ mbedgt -VS --report-junit b.xml
...
mbedgt: exporting to JUnit file 'b.xml'...
exporter_testcase_junit: 'unicodeescape' codec can't decode bytes in position 6469-6471: truncated \xXX escape
exporter_testcase_junit: 'unicodeescape' codec can't decode bytes in position 2772-2774: truncated \xXX escape
exporter_testcase_junit: 'unicodeescape' codec can't decode bytes in position 2494-2495: truncated \UXXXXXXXX escape
exporter_testcase_junit: 'unicodeescape' codec can't decode bytes in position 1816-1817: malformed \N character escape
exporter_testcase_junit: 'unicodeescape' codec can't decode bytes in position 11384-11385: truncated \UXXXXXXXX escape
exporter_testcase_junit: 'unicodeescape' codec can't decode bytes in position 1614-1615: truncated \uXXXX escape
exporter_testcase_junit: 'unicodeescape' codec can't decode bytes in position 1039-1040: truncated \uXXXX escape
exporter_testcase_junit: 'unicodeescape' codec can't decode bytes in position 5693-5694: truncated \UXXXXXXXX escape
...
```