### PR TITLE
Check expression for user specified arguments in hook command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Circle CI](https://circleci.com/gh/ARMmbed/greentea.svg?style=svg)](https://circleci.com/gh/ARMmbed/greentea)
 [![Coverage Status](https://coveralls.io/repos/github/ARMmbed/greentea/badge.svg?branch=master)](https://coveralls.io/github/ARMmbed/greentea?branch=master)
+[![PyPI version](https://badge.fury.io/py/mbed-greentea.svg)](https://badge.fury.io/py/mbed-greentea)
 
 # Table of contents
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ $ source venv/bin/activate
 * Install packages as usual, for example:
 ```
 $ pip install yotta
-$ pip install greentea
+$ pip install mbed-greentea
   pip ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 [![Circle CI](https://circleci.com/gh/ARMmbed/greentea.svg?style=svg)](https://circleci.com/gh/ARMmbed/greentea)
 [![Coverage Status](https://coveralls.io/repos/github/ARMmbed/greentea/badge.svg?branch=master)](https://coveralls.io/github/ARMmbed/greentea?branch=master)
 
-[![Circle CI](https://circleci.com/gh/ARMmbed/greentea/tree/master_v0_1_x.svg?style=svg)](https://circleci.com/gh/ARMmbed/greentea/tree/master_v0_1_x)
-[![Coverage Status](https://coveralls.io/repos/github/ARMmbed/greentea/badge.svg?branch=master_v0_1_x)](https://coveralls.io/github/ARMmbed/greentea?branch=master_v0_1_x)
-
 # Table of contents
 
 * [Introduction](#introduction)

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -380,6 +380,10 @@ def run_test_thread(test_result_queue, test_queue, opts, mut, mut_info, yotta_ta
                                          enum_host_tests_path=enum_host_tests_path,
                                          verbose=verbose)
 
+        # Some error in htrun, abort test execution
+        if host_test_result < 0:
+            break
+        
         single_test_result, single_test_output, single_testduration, single_timeout, result_test_cases, test_cases_summary = host_test_result
         test_result = single_test_result
 

--- a/mbed_greentea/mbed_report_api.py
+++ b/mbed_greentea/mbed_report_api.py
@@ -200,7 +200,10 @@ def exporter_testcase_junit(test_result_ext, test_suite_properties=None):
 
             # tc_elapsed_sec = test['elapsed_time']
             tc_stdout = ''  #test['single_test_output']
-            tc_stderr = test['single_test_output'].decode('unicode_escape').encode('ascii','ignore')
+            try:
+                tc_stderr = test['single_test_output'].decode('unicode_escape').encode('ascii','ignore')
+            except UnicodeDecodeError as e:
+                print "exporter_testcase_junit:", str(e)
 
             # testcase_result stores info about test case results
             testcase_result = test['testcase_result']
@@ -222,7 +225,11 @@ def exporter_testcase_junit(test_result_ext, test_suite_properties=None):
                 utest_log = testcase_result[tc_name].get('utest_log', '')
                 result_text = testcase_result[tc_name].get('result_text', "UNDEF")
 
-                tc_stdout = '\n'.join(utest_log).decode('unicode_escape').encode('ascii','ignore')
+                try:
+                    tc_stdout = '\n'.join(utest_log).decode('unicode_escape').encode('ascii','ignore')
+                except UnicodeDecodeError as e:
+                    print "exporter_testcase_junit:", str(e)
+
                 tc_class = ym_name + '.' + target_name + '.' + test_suite_name
                 tc = TestCase(tc_name, tc_class, duration, tc_stdout, tc_stderr)
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 setup(name='mbed-greentea',
-      version='0.2.3',
+      version='0.2.4',
       description=DESCRIPTION,
       long_description=read('README.md'),
       author=OWNER_NAMES,

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 setup(name='mbed-greentea',
-      version='0.2.5',
+      version='0.2.6',
       description=DESCRIPTION,
       long_description=read('README.md'),
       author=OWNER_NAMES,

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 setup(name='mbed-greentea',
-      version='0.2.4',
+      version='0.2.5',
       description=DESCRIPTION,
       long_description=read('README.md'),
       author=OWNER_NAMES,

--- a/test/mbed_gt_hooks.py
+++ b/test/mbed_gt_hooks.py
@@ -14,6 +14,7 @@ limitations under the License.
 """
 
 import unittest
+from mock import patch
 from mbed_greentea.mbed_greentea_hooks import GreenteaCliTestHook
 
 class GreenteaCliTestHookTest(unittest.TestCase):
@@ -91,6 +92,68 @@ class GreenteaCliTestHookTest(unittest.TestCase):
                 "yotta_target_name" : 'frdm-k64f-gcc'
             }))
 
+    @patch('os.path.exists')
+    @patch('os.path.getsize')
+    def test_check_parameters_arg_n(self, pathGetsize_mock, pathExists_mock):
+        pathExists_mock.return_value = True
+        pathGetsize_mock.return_value = 0
+        self.assertEqual('-a ./build/frdm-k64f-gcc.info',
+            self.cli_hooks.check_parameters('(-a <<./build/frdm-k64f-gcc.info>>):n'))
+
+        pathExists_mock.return_value = False
+        pathGetsize_mock.return_value = 0
+        self.assertEqual('',
+            self.cli_hooks.check_parameters('(-a <<./build/frdm-k64f-gcc.info>>):n'))
+            
+    @patch('os.path.exists')
+    @patch('os.path.getsize')
+    def test_check_parameters_arg_e(self, pathGetsize_mock, pathExists_mock):
+        pathExists_mock.return_value = True
+        pathGetsize_mock.return_value = 1
+        self.assertEqual('-a ./build/frdm-k64f-gcc.info',
+            self.cli_hooks.check_parameters('(-a <<./build/frdm-k64f-gcc.info>>):e'))
+
+        pathExists_mock.return_value = True
+        pathGetsize_mock.return_value = 0
+        self.assertEqual('',
+            self.cli_hooks.check_parameters('(-a <<./build/frdm-k64f-gcc.info>>):e'))
+            
+    @patch('os.path.exists')
+    @patch('os.path.getsize')
+    def test_check_parameters_arg_i(self, pathGetsize_mock, pathExists_mock):
+        pathExists_mock.return_value = True
+        pathGetsize_mock.return_value = 1
+        self.assertEqual('-a ./build/frdm-k64f-gcc.info',
+            self.cli_hooks.check_parameters('(-a <<./build/frdm-k64f-gcc.info>>):i'))
+
+        pathExists_mock.return_value = True
+        pathGetsize_mock.return_value = 0
+        self.assertEqual('',
+            self.cli_hooks.check_parameters('(-a <<./build/frdm-k64f-gcc.info>>):i'))
+
+        pathExists_mock.return_value = False
+        pathGetsize_mock.return_value = 1
+        self.assertEqual('',
+            self.cli_hooks.check_parameters('(-a <<./build/frdm-k64f-gcc.info>>):i'))
+
+        pathExists_mock.return_value = False
+        pathGetsize_mock.return_value = 0
+        self.assertEqual('',
+            self.cli_hooks.check_parameters('(-a <<./build/frdm-k64f-gcc.info>>):i'))
+
+    @patch('os.path.exists')
+    @patch('os.path.getsize')
+    def test_check_parameters_arg_i_multiple(self, pathGetsize_mock, pathExists_mock):
+        pathExists_mock.return_value = True
+        pathGetsize_mock.return_value = 1
+        self.assertEqual('-a ./build/frdm-k64f-gcc.info -b ./build/frdm-k64f-gcc.info',
+            self.cli_hooks.check_parameters('(-a <<./build/frdm-k64f-gcc.info>>):i (-b <<./build/frdm-k64f-gcc.info>>):i'))
+
+        pathExists_mock.return_value = True
+        pathGetsize_mock.return_value = 0
+        self.assertEqual(' -b ./build/frdm-k64f-gcc.info',
+            self.cli_hooks.check_parameters('(-a <<./build/frdm-k64f-gcc.info>>):i -b ./build/frdm-k64f-gcc.info'))
+
     def test_format_before_run_with_1_list_1_string(self):
         # {test_name_list} should expand [] list twice
         # {yotta_target_name} should not be used to expand, only to replace
@@ -99,7 +162,6 @@ class GreenteaCliTestHookTest(unittest.TestCase):
                 "test_name_list" : ['mbed-drivers-test-basic', 'mbed-drivers-test-hello'],
                 "yotta_target_name" : 'frdm-k64f-gcc',
             }))
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Because some test cases for now may not return any LCOV output, an empty test_case_name.info file is generated. This can not be merged to result.info and the automation fails. This PR fixes the issue by enabling a feature to check for empty files or if file exists with new specified arguments

User specified arguments are (so far):
* ```(...<<...>>):n``` -> remove content from hook command if file not exists
* ```(...<<...>>):e```-> remove content from hook command if file exists but empty
* ```(...<<...>>):i```-> remove content from hook command if file not exists OR if file exists but empty

where:
* ```(...)``` -> specify content to check and if necessary removed
* ```<<...>>``` -> specify part which is a path to a file

Example hooks.json:
```
{
    "hooks": {
        "hook_test_end": "",
        "hook_post_test_end": "$lcov --gcov-tool gcov (-a <<./build/{yotta_target_name}/test_case_1.info>>):i --output-file temp_result.info",
        "hook_post_all_test_end": "$lcov --gcov-tool gcov [(-a <<./build/{yotta_target_name}/{test_name_list}.info>>):i] --output-file result.info"
    }
}
```
parameters:
```
yotta_target_name = frdm-k64f-gcc
test_name_list = ['test_case_1', 'test_case_2', 'test_case_3']
```
resulting hook command for "hook_post_test_end" if ```test_case_1.info``` exists and is not empty:
```
$lcov --gcov-tool gcov -a ./build/frdm-k64f-gcc/test_case_1.info --output-file temp_result.info"
```
resulting hook command for "hook_post_all_test_end" if ```test_case_1.info```,  ```test_case_3.info``` exists and is not empty (```test_case_2.info``` is empty):
```
$lcov --gcov-tool gcov -a ./build/frdm-k64f-gcc/test_case_1.info -a ./build/frdm-k64f-gcc/test_case_3.info --output-file temp_result.info"
```

