### PR TITLE
Add lcov hook

### DIFF
--- a/mbed_greentea/mbed_greentea_hooks.py
+++ b/mbed_greentea/mbed_greentea_hooks.py
@@ -13,6 +13,7 @@ limitations under the License.
 Author: Przemyslaw Wirkus <Przemyslaw.wirkus@arm.com>
 """
 
+import os
 import re
 import json
 from subprocess import Popen, PIPE
@@ -140,6 +141,69 @@ class GreenteaCliTestHook(GreenteaTestHook):
                 result = expr.replace(expr_str_orig, delimiter.join(expansion_result))
         return result
 
+class LcovHook(GreenteaCliTestHook):
+    """! Class used to define a LCOV hook
+    """
+    lcov_hooks = {
+        "hooks": {
+            "hook_test_end": "$lcov --gcov-tool gcov  --capture --directory ./build --output-file ./build/{yotta_target_name}/{test_name}.info",
+            "hook_post_all_test_end": "$lcov --gcov-tool gcov [(-a <<./build/{yotta_target_name}/{test_name_list}.info>>)] --output-file result.info"
+        }
+    }
+
+    def __init__(self, name, cmd):
+        GreenteaCliTestHook.__init__(self, name, cmd)
+
+    @staticmethod
+    def format_before_run(cmd, format, verbose=False):
+        if format:
+            # We will expand first
+            cmd_expand = GreenteaCliTestHook.expand_parameters(cmd, format)
+            if cmd_expand:
+                cmd = cmd_expand
+                if verbose:
+                    gt_logger.gt_log_tab("hook expanded: %s"% cmd)
+
+            cmd = cmd.format(**format)
+            cmd = LcovHook.check_if_file_exists_or_is_empty(cmd)
+            if verbose:
+                gt_logger.gt_log_tab("hook formated: %s"% cmd)
+        return cmd
+
+    @staticmethod
+    def check_if_file_exists_or_is_empty(expr):
+        """! Check Expression for specific characters in hook command
+        @param expr Expression to check
+        @details
+        expr = "lcov --gcov-tool gcov (-a <<{build_path}/test/{test_name}.info>>) --output-file result.info"
+            where:
+            (...) -> specify part to check
+            <<...>> -> specify part which is a path to a file
+        'expr' expression (-a <<{build_path}/test/{test_name}.info>>) will be either:
+            "-a ./build/frdm-k64f-gcc/test/test_name.info"
+            or will be removed from command
+        It is also possible to use it in combination with expand_parameters:
+        expr = "lcov --gcov-tool gcov [(-a <<./build/{yotta_target_name}/{test_name_list}.info>>)] --output-file result.info"
+        """
+        result = expr
+        expr_strs_orig = re.findall('\(.*?\)', expr)
+        for expr_str_orig in expr_strs_orig:
+            expr_str_base = expr_str_orig[1:-1]
+            result = result.replace(expr_str_orig, expr_str_base)
+            m = re.search('\<<.*?\>>', expr_str_base)
+            if m:
+                expr_str_path = m.group(0)[2:-2]
+                # Remove option if file not exists OR if file exists but empty
+                if not os.path.exists(expr_str_path):
+                    result = result.replace(expr_str_base, '')
+                elif os.path.getsize(expr_str_path) == 0:
+                    result = result.replace(expr_str_base, '')
+
+        # Remove path limiter
+        result = result.replace('<<', '')
+        result = result.replace('>>', '')
+        return result
+
 class GreenteaHooks():
     """! Class used to store all hooks
     @details Hooks command starts with '$' dollar sign
@@ -149,15 +213,22 @@ class GreenteaHooks():
         """! Opens JSON file with
         """
         try:
-            with open(path_to_hooks, 'r') as data_file:
-                hooks = json.load(data_file)
-                if 'hooks' in hooks:
-                    for hook in hooks['hooks']:
-                        hook_name = hook
-                        hook_expression = hooks['hooks'][hook]
-                        # This is a command line hook
-                        if hook_expression.startswith('$'):
-                            self.HOOKS[hook_name] = GreenteaCliTestHook(hook_name, hook_expression[1:])
+            if path_to_hooks == 'lcov':
+                hooks = LcovHook.lcov_hooks
+                for hook in hooks['hooks']:
+                    hook_name = hook
+                    hook_expression = hooks['hooks'][hook]
+                    self.HOOKS[hook_name] = LcovHook(hook_name, hook_expression[1:])
+            else:
+                with open(path_to_hooks, 'r') as data_file:
+                    hooks = json.load(data_file)
+                    if 'hooks' in hooks:
+                        for hook in hooks['hooks']:
+                            hook_name = hook
+                            hook_expression = hooks['hooks'][hook]
+                            # This is a command line hook
+                            if hook_expression.startswith('$'):
+                                self.HOOKS[hook_name] = GreenteaCliTestHook(hook_name, hook_expression[1:])
         except IOError as e:
             print str(e)
             self.HOOKS = None

--- a/test/mbed_gt_hooks.py
+++ b/test/mbed_gt_hooks.py
@@ -14,12 +14,15 @@ limitations under the License.
 """
 
 import unittest
+from mock import patch
 from mbed_greentea.mbed_greentea_hooks import GreenteaCliTestHook
+from mbed_greentea.mbed_greentea_hooks import LcovHook
 
 class GreenteaCliTestHookTest(unittest.TestCase):
 
     def setUp(self):
         self.cli_hooks = GreenteaCliTestHook('test_hook', 'some command')
+        self.lcov_hooks = LcovHook('test_hook', 'some command')
 
     def tearDown(self):
         pass
@@ -100,6 +103,29 @@ class GreenteaCliTestHookTest(unittest.TestCase):
                 "yotta_target_name" : 'frdm-k64f-gcc',
             }))
 
+    @patch('os.path.exists')
+    @patch('os.path.getsize')
+    def test_check_if_file_exists(self, pathGetsize_mock, pathExists_mock):
+        pathExists_mock.return_value = True
+        self.assertEqual('-a ./build/frdm-k64f-gcc.info',
+            self.lcov_hooks.check_if_file_exists_or_is_empty('(-a <<./build/frdm-k64f-gcc.info>>)'))
+
+        pathExists_mock.return_value = False
+        self.assertEqual('',
+            self.lcov_hooks.check_if_file_exists_or_is_empty('(-a <<./build/frdm-k64f-gcc.info>>)'))
+
+    @patch('os.path.exists')
+    @patch('os.path.getsize')
+    def test_check_if_file_is_empty(self, pathGetsize_mock, pathExists_mock):
+        pathExists_mock.return_value = True
+        pathGetsize_mock.return_value = 1
+        self.assertEqual('-a ./build/frdm-k64f-gcc.info',
+            self.lcov_hooks.check_if_file_exists_or_is_empty('(-a <<./build/frdm-k64f-gcc.info>>)'))
+
+        pathExists_mock.return_value = True
+        pathGetsize_mock.return_value = 0
+        self.assertEqual('',
+            self.lcov_hooks.check_if_file_exists_or_is_empty('(-a <<./build/frdm-k64f-gcc.info>>)'))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Introduction
Because some test cases for now may not return any LCOV output, an empty test_case_name.info file is generated. This can not be merged to result.info and the automation fails. This PR fixes the issue by enabling a feature to check for empty files or if file exists.

## Usage
To enable code coverage use:
```
mbedgt -VS --hooks=lcov
```
By using a hook named ```lcov``` code coverage output is enabled and the files are autoamtically checked if they exists or empty.


