### PR TITLE
Respect base_path for binary paths

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -735,7 +735,9 @@ def main_cli(opts, args, gt_instance_uuid=None):
                 random.shuffle(filtered_ctest_test_list_keys, lambda: shuffle_random_seed)
 
             for test_name in filtered_ctest_test_list_keys:
-                image_path = filtered_ctest_test_list[test_name].get_binary(binary_type=TestBinary.BIN_TYPE_BOOTABLE).get_path()
+                test_spec_path = os.path.dirname(opts.test_spec)
+                bin_path = filtered_ctest_test_list[test_name].get_binary(binary_type=TestBinary.BIN_TYPE_BOOTABLE).get_path()
+                image_path = os.path.join(test_spec_path, build_path, bin_path)
                 if image_path is None:
                     gt_logger.gt_log_err("Failed to find test binary for test %s flash method %s" % (test_name, 'usb'))
                 else:


### PR DESCRIPTION
This solves the issue described in #114.

If the base_path is not intended to have an effect on the binary paths, then the binary paths should at least be relative to the test_spec file, not the current working directory of greentea.