### PR TITLE
Simple system info report for debug / support

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -46,6 +46,7 @@ from mbed_greentea.mbed_yotta_api import get_test_spec_from_yt_module
 from mbed_greentea.mbed_greentea_hooks import GreenteaHooks
 from mbed_greentea.tests_spec import TestSpec, TestBinary
 from mbed_greentea.mbed_target_info import get_platform_property
+from mbed_info import mbed_get_global_info
 
 try:
     import mbed_lstools
@@ -197,6 +198,12 @@ def main():
                     action="store_true",
                     help='List available binaries')
 
+    parser.add_option('', '--info',
+                    dest='system_info',
+                    default=False,
+                    action="store_true",
+                    help='Prints system info in JSON format')
+
     parser.add_option('-m', '--map-target',
                     dest='map_platform_to_yt_target',
                     help='List of custom mapping between platform name and yotta target. Comma separated list of PLATFORM:TARGET tuples')
@@ -332,7 +339,7 @@ def main():
             gt_logger.gt_log_tab(str(e))
             raise
 
-    if not any([opts.list_binaries, opts.version]):
+    if not any([opts.list_binaries, opts.version, opts.system_info]):
         delta = time() - start  # Test execution time delta
         gt_logger.gt_log("completed in %.2f sec"% delta)
 
@@ -381,7 +388,7 @@ def run_test_thread(test_result_queue, test_queue, opts, mut, build, build_path,
         # Some error in htrun, abort test execution
         if host_test_result < 0:
             break
-        
+
         single_test_result, single_test_output, single_testduration, single_timeout, result_test_cases, test_cases_summary = host_test_result
         test_result = single_test_result
 
@@ -545,6 +552,11 @@ def main_cli(opts, args, gt_instance_uuid=None):
     # Prints version and exits
     if opts.version:
         print_version()
+        return (0)
+
+    # Prints system info (for debug purposes) and exits
+    if opts.system_info:
+        print mbed_get_global_info()
         return (0)
 
     # Detect Source of test spec

--- a/mbed_greentea/mbed_info.py
+++ b/mbed_greentea/mbed_info.py
@@ -42,27 +42,25 @@ def mbed_get_global_info():
     info_dict = dict()
 
     info_dict['os'] = dict()
-    info_dict['mbed-tools'] = dict()
+    info_dict['dependencies'] = dict()
     info_dict['python'] = dict()
 
     info_dict['os']['os_info'] = mbed_os_info()
-    info_dict['os']['uname'] = platform.uname()
 
     info_dict['os']['details'] = dict()
     info_dict['os']['details']['os_mac'] = platform.mac_ver()
     info_dict['os']['details']['os_linux'] = platform.linux_distribution()
     info_dict['os']['details']['os_win'] = platform.win32_ver()
 
-    info_dict['python']['version_info'] = str(sys.version_info)
     info_dict['python']['version'] =  platform.python_version()
 
-    info_dict['mbed-tools']['packages'] = dict()
-    info_dict['mbed-tools']['details'] = dict()
+    info_dict['dependencies']['packages'] = dict()
+    info_dict['dependencies']['details'] = dict()
 
     for pkg in packages:
         version = pkg_resources.require(pkg)[0].version
-        info_dict['mbed-tools']['packages'][pkg] = version
-        info_dict['mbed-tools']['details'][pkg] = [str(x) for x in pkg_resources.require(pkg)]
+        info_dict['dependencies']['packages'][pkg] = version
+        info_dict['dependencies']['details'][pkg] = [str(x) for x in pkg_resources.require(pkg)]
 
     #print json.dumps(info_dict, indent=4)
     return json.dumps(info_dict, indent=4)

--- a/mbed_greentea/mbed_info.py
+++ b/mbed_greentea/mbed_info.py
@@ -1,0 +1,68 @@
+"""
+mbed SDK
+Copyright (c) 2011-2015 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Author: Przemyslaw Wirkus <Przemyslaw.Wirkus@arm.com>
+"""
+
+import os
+import sys
+import json
+import platform
+import pkg_resources  # part of setuptools
+
+
+packages = ['mbed-greentea', 'mbed-host-tests', 'mbed-ls', 'pyserial']
+
+def mbed_os_info():
+    """! Returns information about host OS
+    @return Returns tuple with information about OS and host platform
+    """
+    result = (os.name,
+              platform.system(),
+              platform.release(),
+              platform.version(),
+              sys.platform)
+    return result
+
+
+def mbed_get_global_info():
+    info_dict = dict()
+
+    info_dict['os'] = dict()
+    info_dict['mbed-tools'] = dict()
+    info_dict['python'] = dict()
+
+    info_dict['os']['os_info'] = mbed_os_info()
+    info_dict['os']['uname'] = platform.uname()
+
+    info_dict['os']['details'] = dict()
+    info_dict['os']['details']['os_mac'] = platform.mac_ver()
+    info_dict['os']['details']['os_linux'] = platform.linux_distribution()
+    info_dict['os']['details']['os_win'] = platform.win32_ver()
+
+    info_dict['python']['version_info'] = str(sys.version_info)
+    info_dict['python']['version'] =  platform.python_version()
+
+    info_dict['mbed-tools']['packages'] = dict()
+    info_dict['mbed-tools']['details'] = dict()
+
+    for pkg in packages:
+        version = pkg_resources.require(pkg)[0].version
+        info_dict['mbed-tools']['packages'][pkg] = version
+        info_dict['mbed-tools']['details'][pkg] = [str(x) for x in pkg_resources.require(pkg)]
+
+    #print json.dumps(info_dict, indent=4)
+    return json.dumps(info_dict, indent=4)


### PR DESCRIPTION
## Description
* There is a need to easily report test tools versions so users can report them to team.
* This PR adds kernel of a functionality to print information about system and tools/Python packages used to run test environment.
* It will help us to diagnose certain issues reported by external and internal tools users.


## Changes:
* Add --info switch, prints system info and exits

## Example

Simple command:
```
$ mbedgt --info
```

or if you want to dump JSON data directly to file ```filename.json```:
```
mbedgt --info > filename.json
```

Prints in JSON formatted output data regarding system and mbed tools packages manes / versions / dependencies:

Example output:
```json
{
    "python": {
        "version": "2.7.11",
        "version_info": "sys.version_info(major=2, minor=7, micro=11, releaselevel='final', serial=0)"
    },
    "mbed-tools": {
        "packages": {
            "mbed-ls": "0.2.6",
            "pyserial": "3.0.1",
            "mbed-host-tests": "0.2.6",
            "mbed-greentea": "0.2.10"
        },
        "details": {
            "mbed-ls": [
                "mbed-ls 0.2.6",
                "prettytable 0.7.2"
            ],
            "pyserial": [
                "pyserial 3.0.1"
            ],
            "mbed-host-tests": [
                "mbed-host-tests 0.2.6",
                "prettytable 0.7.2",
                "pyserial 3.0.1"
            ],
            "mbed-greentea": [
                "mbed-greentea 0.2.10",
                "colorama 0.3.7",
                "mock 1.3.0",
                "lockfile 0.12.2",
                "junit-xml 1.6",
                "mbed-ls 0.2.6",
                "mbed-host-tests 0.2.6",
                "pyserial 3.0.1",
                "prettytable 0.7.2",
                "six 1.10.0",
                "funcsigs 0.4",
                "pbr 1.8.1",
                "six 1.10.0"
            ]
        }
    },
    "os": {
        "uname": [
            "Windows",
            "username",
            "7",
            "6.1.7601",
            "AMD64",
            "Intel64 Family 6 Model 58 Stepping 9, GenuineIntel"
        ],
        "details": {
            "os_win": [
                "7",
                "6.1.7601",
                "SP1",
                "Multiprocessor Free"
            ]
        },
        "os_info": [
            "nt",
            "Windows",
            "7",
            "6.1.7601",
            "win32"
        ]
    }
}
```