### PR TITLE
Issue with JUNIT reporter, switch --report-junit affected

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -43,6 +43,7 @@ from mbed_greentea.mbed_greentea_dlm import greentea_get_app_sem
 from mbed_greentea.mbed_greentea_dlm import greentea_update_kettle
 from mbed_greentea.mbed_greentea_dlm import greentea_clean_kettle
 from mbed_greentea.mbed_yotta_api import get_test_spec_from_yt_module
+from mbed_greentea.mbed_yotta_api import get_test_suite_properties
 from mbed_greentea.mbed_greentea_hooks import GreenteaHooks
 from mbed_greentea.tests_spec import TestSpec, TestBinary
 from mbed_greentea.mbed_target_info import get_platform_property
@@ -832,7 +833,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
         # Reports (to file)
         if opts.report_junit_file_name:
             gt_logger.gt_log("exporting to JUnit file '%s'..."% gt_logger.gt_bright(opts.report_junit_file_name))
-            junit_report = exporter_testcase_junit(test_report)
+            junit_report = exporter_testcase_junit(test_report, test_suite_properties = get_test_suite_properties())
             with open(opts.report_junit_file_name, 'w') as f:
                 f.write(junit_report)
         if opts.report_text_file_name:

--- a/mbed_greentea/mbed_report_api.py
+++ b/mbed_greentea/mbed_report_api.py
@@ -189,7 +189,10 @@ def exporter_testcase_junit(test_result_ext, test_suite_properties=None):
     """
     from junit_xml import TestSuite, TestCase
 
-    ym_name = test_suite_properties.get('name', 'unknown')
+    # Only check test suite properties if argument is valid
+    ym_name = 'unknown'
+    if test_suite_properties:
+        ym_name = test_suite_properties.get('name', 'unknown')
 
     test_suites = []
 

--- a/mbed_greentea/mbed_yotta_api.py
+++ b/mbed_greentea/mbed_yotta_api.py
@@ -190,3 +190,15 @@ def get_test_spec_from_yt_module(opts):
             tb.add_test(name, t)
 
     return test_spec
+
+def get_test_suite_properties():
+    """ Read data from module.json to help reporter do its job
+
+    @return Stuff in format of yotta module.json
+    """
+
+    ### Read yotta module basic information
+    yotta_module = YottaModule()
+    if yotta_module.init():
+        return yotta_module.get_data()
+    return None


### PR DESCRIPTION
## Description

Recent changes:
* https://github.com/ARMmbed/greentea/releases/tag/v0.2.10 ->
* https://github.com/ARMmbed/greentea/pull/113 -> 
* https://github.com/ARMmbed/greentea/pull/113/files#diff-dede25ea3355a799ef1ec00a411ffd73L942
influenced reporters, especially JUnit reporter which is expecting test_suite_properties passed to it.

Problem:
* When calling ```mbedgt``` with ```--report-junit``` we have a traceback because JUNIT reporter function receives ```None``` as a optional parameter value.
* I've added simple guard around it in second commit, but first commit actually adds yotta module info to reporter so reporter can produce better reports with yotta module name etc.
* In the future we can add support for New Configuration JSON file and pass it to reporter to achieve the same verbosity.

Changes being done:
* Added support for yotta module for JUNIT reporter.
* Added guard around JUNIT reporte's ```test_suite_properties```.

## Traceback
```
$ mbedgt -VS --report-junit file.xml
```
```
Traceback (most recent call last):
  File "c:\Python27.11\Scripts\mbedgt-script.py", line 9, in <module>
    load_entry_point('mbed-greentea', 'console_scripts', 'mbedgt')()
  File "c:\work\pypi\greentea\mbed_greentea\mbed_greentea_cli.py", line 326, in main
    cli_ret = main_cli(opts, args)
  File "c:\work\pypi\greentea\mbed_greentea\mbed_greentea_cli.py", line 835, in main_cli
    junit_report = exporter_testcase_junit(test_report)
  File "c:\work\pypi\greentea\mbed_greentea\mbed_report_api.py", line 192, in exporter_testcase_junit
    ym_name = test_suite_properties.get('name', 'unknown')
AttributeError: 'NoneType' object has no attribute 'get'
```

@mazimkhan @adbridge @bridadan 