### PR TITLE
Patches on top of Greentea v0.2.11 (bug-fixes and allignment with test specification feature)

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -382,7 +382,7 @@ def run_test_thread(test_result_queue, test_queue, opts, mut, build, build_path,
         # Some error in htrun, abort test execution
         if host_test_result < 0:
             break
-        
+
         single_test_result, single_test_output, single_testduration, single_timeout, result_test_cases, test_cases_summary = host_test_result
         test_result = single_test_result
 
@@ -833,7 +833,9 @@ def main_cli(opts, args, gt_instance_uuid=None):
         # Reports (to file)
         if opts.report_junit_file_name:
             gt_logger.gt_log("exporting to JUnit file '%s'..."% gt_logger.gt_bright(opts.report_junit_file_name))
-            junit_report = exporter_testcase_junit(test_report, test_suite_properties = get_test_suite_properties())
+            # This test specification will be used by JUnit exporter to populate TestSuite.properties (useful meta-data for Viewer)
+            junit_test_spec = test_spec if opts.test_spec else None
+            junit_report = exporter_testcase_junit(test_report, test_suite_properties = get_test_suite_properties(test_spec=junit_test_spec))
             with open(opts.report_junit_file_name, 'w') as f:
                 f.write(junit_report)
         if opts.report_text_file_name:

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -148,7 +148,7 @@ def main():
 
     parser.add_option('-t', '--target',
                     dest='list_of_targets',
-                    help='You can specify list of yotta targets you want to build. Use comma to sepatate them.' +
+                    help='You can specify list of yotta targets you want to build. Use comma to separate them.' +
                          'Note: If --test-spec switch is defined this list becomes optional list of builds you want to filter in your test:' +
                          'Comma separated list of builds from test specification. Applicable if --test-spec switch is specified')
 

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -93,7 +93,14 @@ def print_version(verbose=True):
     return version
 
 
-def create_filtered_test_list(ctest_test_list, test_by_names, skip_test):
+def create_filtered_test_list(ctest_test_list, test_by_names, skip_test, test_spec=None):
+    """! Filters test case list (filtered with switch -n) and return filtered list.
+    @ctest_test_list List iof tests, originally from CTestTestFile.cmake in yotta module. Now comes from test specification
+    @test_by_names Command line switch -n <test_by_names>
+    @skip_test Command line switch -i <skip_test>
+    @param test_spec Command line switch --test-spec <test_spec_filename>
+    @return
+    """
     filtered_ctest_test_list = ctest_test_list
     test_list = None
     invalid_test_names = []
@@ -125,7 +132,10 @@ def create_filtered_test_list(ctest_test_list, test_by_names, skip_test):
         opt_to_print = '-n' if test_by_names else 'skip-test'
         gt_logger.gt_log_warn("invalid test case names (specified with '%s' option)"% opt_to_print)
         for test_name in invalid_test_names:
-            gt_logger.gt_log_warn("test name '%s' not found in CTestTestFile.cmake (specified with '%s' option)"% (gt_logger.gt_bright(test_name),opt_to_print))
+            if test_spec:
+                gt_logger.gt_log_warn("test name '%s' not found in '%s' (specified with --test-spec option)"% (gt_logger.gt_bright(test_name), gt_logger.gt_bright(test_spec)))
+            else:
+                gt_logger.gt_log_warn("test name '%s' not found in CTestTestFile.cmake (specified with '%s' option)"% (gt_logger.gt_bright(test_name), opt_to_print))
         gt_logger.gt_log_tab("note: test case names are case sensitive")
         gt_logger.gt_log_tab("note: see list of available test cases below")
         list_binaries_for_targets(verbose_footer=False)
@@ -725,7 +735,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
                 continue
 
             test_list = test_build.get_tests()
-            filtered_ctest_test_list = create_filtered_test_list(test_list, opts.test_by_names, opts.skip_test)
+            filtered_ctest_test_list = create_filtered_test_list(test_list, opts.test_by_names, opts.skip_test, test_spec=opts.test_spec)
 
             gt_logger.gt_log("running %d test%s for platform '%s' and toolchain '%s'"% (
                 len(filtered_ctest_test_list),

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -30,6 +30,7 @@ from threading import Thread
 
 
 from mbed_greentea.mbed_test_api import run_host_test
+from mbed_greentea.mbed_test_api import log_mbed_devices_properties
 from mbed_greentea.mbed_test_api import TEST_RESULTS
 from mbed_greentea.mbed_test_api import TEST_RESULT_OK, TEST_RESULT_FAIL
 from mbed_greentea.cmake_handlers import list_binaries_for_targets
@@ -137,7 +138,9 @@ def main():
 
     parser.add_option('-t', '--target',
                     dest='list_of_targets',
-                    help='You can specify list of targets you want to build. Use comma to sepatate them')
+                    help='You can specify list of yotta targets you want to build. Use comma to sepatate them.' +
+                         'Note: If --test-spec switch is defined this list becomes optional list of builds you want to filter in your test:' +
+                         'Comma separated list of builds from test specification. Applicable if --test-spec switch is specified')
 
     parser.add_option('-n', '--test-by-names',
                     dest='test_by_names',
@@ -646,11 +649,13 @@ def main_cli(opts, args, gt_instance_uuid=None):
         shuffle_random_seed = round(float(opts.shuffle_test_seed), SHUFFLE_SEED_ROUND)
 
     ### Testing procedures, for each target, for each target's compatible platform
-    for test_build in test_spec.get_test_builds():
+    # In case we are using test spec (switch --test-spec) command line option -t <list_of_targets>
+    # is used to enumerate builds from test spec we are suppling
+    filter_test_builds = opts.list_of_targets.split(',') if opts.list_of_targets else None
+    for test_build in test_spec.get_test_builds(filter_test_builds):
         platform_name = test_build.get_platform()
         gt_logger.gt_log("processing target '%s' toolchain '%s' compatible platforms..." %
-                         (gt_logger.gt_bright(platform_name),
-                                             gt_logger.gt_bright(test_build.get_toolchain())))
+                         (gt_logger.gt_bright(platform_name), gt_logger.gt_bright(test_build.get_toolchain())))
 
         baudrate = test_build.get_baudrate()
 
@@ -666,9 +671,9 @@ def main_cli(opts, args, gt_instance_uuid=None):
                 mbed_dev['serial_port'] = "%s:%d" % (mbed_dev['serial_port'], baudrate)
                 mut = mbed_dev
                 muts_to_test.append(mbed_dev)
+                # Log on screen mbed device properties
                 gt_logger.gt_log("using platform '%s' for test:"% gt_logger.gt_bright(platform_name))
-                for k in mbed_dev:
-                    gt_logger.gt_log_tab("%s = '%s'"% (k, mbed_dev[k]))
+                log_mbed_devices_properties(mbed_dev, verbose=opts.verbose)
                 if number_of_parallel_instances < parallel_test_exec:
                     number_of_parallel_instances += 1
                 else:
@@ -678,6 +683,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
         if opts.verbose_test_configuration_only:
             continue
 
+        ### If we have at least one available device we can proceed
         if mut:
             target_platforms_match += 1
 
@@ -745,48 +751,48 @@ def main_cli(opts, args, gt_instance_uuid=None):
 
             number_of_threads = 0
             for mut in muts_to_test:
-                #################################################################
                 # Experimental, parallel test execution
-                #################################################################
                 if number_of_threads < parallel_test_exec:
                     args = (test_result_queue, test_queue, opts, mut, build, build_path, greentea_hooks)
                     t = Thread(target=run_test_thread, args=args)
                     execute_threads.append(t)
                     number_of_threads += 1
 
-    gt_logger.gt_log_tab("use %s instance%s for testing" % (len(execute_threads), 's' if len(execute_threads) != 1 else ''))
-    for t in execute_threads:
-        t.daemon = True
-        t.start()
+        gt_logger.gt_log_tab("use %s instance%s for testing" % (len(execute_threads), 's' if len(execute_threads) != 1 else ''))
+        for t in execute_threads:
+            t.daemon = True
+            t.start()
 
-    # merge partial test reports from diffrent threads to final test report
-    for t in execute_threads:
-        try:
-            t.join() #blocking
-            test_return_data = test_result_queue.get(False)
-        except Exception as e:
-            # No test report generated
-            gt_logger.gt_log_err("could not generate test report" + str(e))
-            test_exec_retcode += -1000
-            return test_exec_retcode
+        # merge partial test reports from different threads to final test report
+        for t in execute_threads:
+            try:
+                t.join() #blocking
+                test_return_data = test_result_queue.get(False)
+            except Exception as e:
+                # No test report generated
+                gt_logger.gt_log_err("could not generate test report" + str(e))
+                test_exec_retcode += -1000
+                return test_exec_retcode
 
-        test_platforms_match += test_return_data['test_platforms_match']
-        test_exec_retcode += test_return_data['test_exec_retcode']
-        partial_test_report = test_return_data['test_report']
-        # todo: find better solution, maybe use extend
-        for report_key in partial_test_report.keys():
-            if report_key not in test_report:
-                test_report[report_key] = {}
-                test_report.update(partial_test_report)
-            else:
-                test_report[report_key].update(partial_test_report[report_key])
+            test_platforms_match += test_return_data['test_platforms_match']
+            test_exec_retcode += test_return_data['test_exec_retcode']
+            partial_test_report = test_return_data['test_report']
+            # todo: find better solution, maybe use extend
+            for report_key in partial_test_report.keys():
+                if report_key not in test_report:
+                    test_report[report_key] = {}
+                    test_report.update(partial_test_report)
+                else:
+                    test_report[report_key].update(partial_test_report[report_key])
 
-    if opts.verbose_test_configuration_only:
-        print
-        print "Example: execute 'mbedgt --target=TARGET_NAME' to start testing for TARGET_NAME target"
-        return (0)
+        execute_threads = []
 
-    gt_logger.gt_log("all tests finished!")
+        if opts.verbose_test_configuration_only:
+            print
+            print "Example: execute 'mbedgt --target=TARGET_NAME' to start testing for TARGET_NAME target"
+            return (0)
+
+        gt_logger.gt_log("all tests finished!")
 
     # We will execute post test hooks on tests
     for build_name in test_report:

--- a/mbed_greentea/mbed_report_api.py
+++ b/mbed_greentea/mbed_report_api.py
@@ -245,7 +245,7 @@ def exporter_testcase_junit(test_result_ext, test_suite_properties=None):
                 test_cases.append(tc)
 
             ts_name = ym_name + '.' + target_name
-            ts = TestSuite(ts_name, test_cases)
+            ts = TestSuite(ts_name, test_cases, properties=test_suite_properties)
             test_suites.append(ts)
 
     return TestSuite.to_xml_string(test_suites)

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -373,3 +373,13 @@ def run_cli_process(cmd):
     p = Popen(cmd, stdout=PIPE, stderr=PIPE)
     _stdout, _stderr = p.communicate()
     return _stdout, _stderr, p.returncode
+
+def log_mbed_devices_properties(mbed_dev, verbose=False):
+    """! Separate function to log mbed device properties on the screen
+    """
+    # Short subset of MUT properties in verbose mode
+    dev_prop_short = ['target_id', 'mount_point', 'serial_port', 'daplink_version']
+
+    dev_prop = [x for x in mbed_dev.keys() if x in dev_prop_short] if verbose else mbed_dev.keys()
+    for k in dev_prop:
+        gt_logger.gt_log_tab("%s = '%s'"% (k, mbed_dev[k]))

--- a/mbed_greentea/mbed_yotta_api.py
+++ b/mbed_greentea/mbed_yotta_api.py
@@ -191,14 +191,29 @@ def get_test_spec_from_yt_module(opts):
 
     return test_spec
 
-def get_test_suite_properties():
+def get_test_suite_properties(test_spec=None):
     """ Read data from module.json to help reporter do its job
 
+    If test_spec provided function will arrange JUNit test suite properties in a way report viewer can take advantage of it.
+    Test suite properties should be compatible with mbedmicro/mbed properties.
+    If no test_spec we will use module.json data as properties for Test Suite.
+
+    @param test_spec Test specification object (class TestSpec) used with --test-spec switch.
+                     This is used to add extra properties to JUnit test suite report.
     @return Stuff in format of yotta module.json
     """
 
-    ### Read yotta module basic information
-    yotta_module = YottaModule()
-    if yotta_module.init():
-        return yotta_module.get_data()
+    if test_spec:
+        result = dict()
+        first_test_spec = test_spec.get_test_builds()
+        if first_test_spec:
+            first_build = first_test_spec[0]
+            result['toolchain'] = first_build.get_toolchain()
+            result['target'] = first_build.get_platform()
+            return result
+    else:
+        ### Read yotta module basic information
+        yotta_module = YottaModule()
+        if yotta_module.init():
+            return yotta_module.get_data()
     return None

--- a/mbed_greentea/mbed_yotta_api.py
+++ b/mbed_greentea/mbed_yotta_api.py
@@ -208,6 +208,7 @@ def get_test_suite_properties(test_spec=None):
         first_test_spec = test_spec.get_test_builds()
         if first_test_spec:
             first_build = first_test_spec[0]
+            result['name'] = first_build.get_name()
             result['toolchain'] = first_build.get_toolchain()
             result['target'] = first_build.get_platform()
             return result

--- a/mbed_greentea/mbed_yotta_module_parse.py
+++ b/mbed_greentea/mbed_yotta_module_parse.py
@@ -92,14 +92,17 @@ class YottaModule():
         """! Loads yotta_module.json as an object from local yotta build directory
         @return True if data was successfuly loaded from the file
         """
+        self.__yotta_module = dict()
+
         try:
             path = os.path.join(self.MODULE_PATH, self.YOTTA_CONFIG_NAME)
-            with open(path, 'r') as data_file:
-                self.__yotta_module = json.load(data_file)
+            if os.path.exists(path):
+                # Load module.json only if it exists
+                with open(path, 'r') as data_file:
+                    self.__yotta_module = json.load(data_file)
         except IOError as e:
             print "YottaModule: error - ", str(e)
-            self.__yotta_module = {}
-        return bool(len(self.__yotta_module))
+        return bool(self.__yotta_module)    # bool({}) == False
 
     def set_yotta_module(self, yotta_module):
         self.__yotta_module = yotta_module

--- a/mbed_greentea/tests_spec.py
+++ b/mbed_greentea/tests_spec.py
@@ -241,7 +241,7 @@ class TestSpec:
         :return:
         """
         assert TestSpec.KW_BUILDS, "Test spec should contain key '%s'" % TestSpec.KW_BUILDS
-        for _, build in spec[TestSpec.KW_BUILDS].iteritems():
+        for build_name, build in spec[TestSpec.KW_BUILDS].iteritems():
             mandatory_keys = [TestBuild.KW_PLATFORM, TestBuild.KW_TOOLCHAIN,
                               TestBuild.KW_BAUD_RATE,
                               TestBuild.KW_BUILD_BASE_PATH]
@@ -253,14 +253,15 @@ class TestSpec:
             platform = build[TestBuild.KW_PLATFORM]
             toolchain = build[TestBuild.KW_TOOLCHAIN]
 
-            build_name = build.get(TestBuild.KW_TEST_BUILD_NAME, "%s-%s" % (platform, toolchain))
+            # If there is no 'name' property in build, we will use build key as build name
+            name = build.get(TestBuild.KW_TEST_BUILD_NAME, build_name)
 
-            tb = TestBuild(build_name, platform, toolchain,
+            tb = TestBuild(name, platform, toolchain,
                            build[TestBuild.KW_BAUD_RATE],
                            build[TestBuild.KW_BUILD_BASE_PATH],
                            build.get(TestBuild.KW_BIN_TYPE, None))
             tb.parse(build)
-            self.__target_test_spec[build_name] = tb
+            self.__target_test_spec[name] = tb
 
     def get_test_builds(self):
         """

--- a/mbed_greentea/tests_spec.py
+++ b/mbed_greentea/tests_spec.py
@@ -263,12 +263,22 @@ class TestSpec:
             tb.parse(build)
             self.__target_test_spec[name] = tb
 
-    def get_test_builds(self):
+    def get_test_builds(self, filter_by_names=None):
         """
         Gives test builds.
+        :param filter_by_names: List of names of builds you want to filter in your result
         :return:
         """
-        return self.__target_test_spec.values()
+        result = []
+        if filter_by_names:
+            assert type(filter_by_names) is list
+            for tb in self.__target_test_spec.values():
+                if tb.get_name() in filter_by_names:
+                    result.append(tb)
+        else:
+            # When filtering by name is not defined we will return all builds objects
+            result = self.__target_test_spec.values()
+        return result
 
     def get_test_build(self, build_name):
         """

--- a/mbed_greentea/tests_spec.py
+++ b/mbed_greentea/tests_spec.py
@@ -245,9 +245,9 @@ class TestSpec:
             mandatory_keys = [TestBuild.KW_PLATFORM, TestBuild.KW_TOOLCHAIN,
                               TestBuild.KW_BAUD_RATE,
                               TestBuild.KW_BUILD_BASE_PATH]
-            print set(mandatory_keys)
-            print set(build.keys())
-            print set(mandatory_keys).issubset(set(build.keys()))
+            #print set(mandatory_keys)
+            #print set(build.keys())
+            #print set(mandatory_keys).issubset(set(build.keys()))
             assert set(mandatory_keys).issubset(set(build.keys())), \
                 "Build spec should contain keys [%s]. It has [%s]" % (",".join(mandatory_keys), ",".join(build.keys()))
             platform = build[TestBuild.KW_PLATFORM]

--- a/test/mbed_gt_tests_spec.py
+++ b/test/mbed_gt_tests_spec.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python
+"""
+mbed SDK
+Copyright (c) 2011-2015 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+from mbed_greentea.tests_spec import TestSpec, TestBinary
+
+simple_test_spec = {
+    "builds": {
+        "K64F-ARM": {
+            "platform": "K64F",
+            "toolchain": "ARM",
+            "base_path": "./.build/K64F/ARM",
+            "baud_rate": 115200,
+            "tests": {
+                "mbed-drivers-test-generic_tests":{
+                    "binaries":[
+                        {
+                            "binary_type": "bootable",
+                            "path": "./.build/K64F/ARM/mbed-drivers-test-generic_tests.bin"
+                        }
+                    ]
+                },
+                "mbed-drivers-test-c_strings":{
+                    "binaries":[
+                        {
+                            "binary_type": "bootable",
+                            "path": "./.build/K64F/ARM/mbed-drivers-test-c_strings.bin"
+                        }
+                    ]
+                }
+            }
+        },
+        "K64F-GCC": {
+            "platform": "K64F",
+            "toolchain": "GCC_ARM",
+            "base_path": "./.build/K64F/GCC_ARM",
+            "baud_rate": 9600,
+            "tests": {
+                "mbed-drivers-test-generic_tests":{
+                    "binaries":[
+                        {
+                            "binary_type": "bootable",
+                            "path": "./.build/K64F/GCC_ARM/mbed-drivers-test-generic_tests.bin"
+                        }
+                    ]
+                }
+
+            }
+        }
+
+    }
+}
+
+
+class TestsSpecFunctionality(unittest.TestCase):
+
+    def setUp(self):
+        self.ts_2_builds = simple_test_spec
+
+    def tearDown(self):
+        pass
+
+    def test_example(self):
+        self.assertEqual(True, True)
+        self.assertNotEqual(True, False)        
+
+    def test_get_test_builds(self):
+        self.test_spec = TestSpec()
+        self.test_spec.parse(self.ts_2_builds)
+        test_builds = self.test_spec.get_test_builds()
+
+        self.assertIs(type(test_builds), list)
+        self.assertEqual(len(test_builds), 2)
+
+    def test_get_test_builds_names(self):
+        self.test_spec = TestSpec()
+        self.test_spec.parse(self.ts_2_builds)
+        test_builds = self.test_spec.get_test_builds()
+        test_builds_names = [x.get_name() for x in self.test_spec.get_test_builds()]
+
+        self.assertEqual(len(test_builds_names), 2)
+        self.assertIs(type(test_builds_names), list)
+        
+        self.assertIn('K64F-ARM', test_builds_names)
+        self.assertIn('K64F-GCC', test_builds_names)
+
+    def test_get_test_build(self):
+        self.test_spec = TestSpec()
+        self.test_spec.parse(self.ts_2_builds)
+        test_builds = self.test_spec.get_test_builds()
+        test_builds_names = [x.get_name() for x in self.test_spec.get_test_builds()]
+        
+        self.assertEqual(len(test_builds_names), 2)
+        self.assertIs(type(test_builds_names), list)
+        
+        self.assertNotEqual(None, self.test_spec.get_test_build('K64F-ARM'))
+        self.assertNotEqual(None, self.test_spec.get_test_build('K64F-GCC'))
+
+    def test_get_build_properties(self):
+        self.test_spec = TestSpec()
+        self.test_spec.parse(self.ts_2_builds)
+        test_builds = self.test_spec.get_test_builds()
+        test_builds_names = [x.get_name() for x in self.test_spec.get_test_builds()]
+        
+        self.assertEqual(len(test_builds_names), 2)
+        self.assertIs(type(test_builds_names), list)
+        
+        k64f_arm = self.test_spec.get_test_build('K64F-ARM')
+        k64f_gcc = self.test_spec.get_test_build('K64F-GCC')
+        
+        self.assertNotEqual(None, k64f_arm)
+        self.assertNotEqual(None, k64f_gcc)
+    
+        self.assertEqual('K64F', k64f_arm.get_platform())
+        self.assertEqual('ARM', k64f_arm.get_toolchain())
+        self.assertEqual(115200, k64f_arm.get_baudrate())
+
+        self.assertEqual('K64F', k64f_gcc.get_platform())
+        self.assertEqual('GCC_ARM', k64f_gcc.get_toolchain())
+        self.assertEqual(9600, k64f_gcc.get_baudrate())
+
+    def test_get_test_builds_properties(self):
+        self.test_spec = TestSpec()
+        self.test_spec.parse(self.ts_2_builds)
+        test_builds = self.test_spec.get_test_builds()
+        test_builds_names = [x.get_name() for x in self.test_spec.get_test_builds()]
+        
+        self.assertIn('K64F-ARM', test_builds_names)
+        self.assertIn('K64F-GCC', test_builds_names)        
+
+        
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description
Changes:
* Add filter by name for `TestSpec.get_test_builds()`
  * Polishing: Remove debug prints from [tests_spec](https://github.com/ARMmbed/greentea/blob/master/mbed_greentea/tests_spec.py)
* Bug-fix for #119
* Add correct prints to warnings (switch `-n`)
* `YottaModule` functionality polishing
* Add to `Junit.TestSuite.properties` values of `toolchain` and `target` so Viewer can take produce reporting.

```xml
<?xml version="1.0" ?>
<testsuites errors="0" failures="0" skipped="0" tests="4" time="0.300000190735">
	<testsuite errors="0" failures="0" name="unknown.frdm-k64f-gcc" skipped="0" tests="4" time="0.300000190735">
		<properties>
			<property name="toolchain" value="GCC_ARM"/>
			<property name="target" value="K64F"/>
		</properties>
```

* Error should be reported only if module.json exists but we were unable to load it for some reason

Example log with this issue: http://e108747.cambridge.arm.com:8080/job/mb/17/console
```
14:32:49 mbedgt: exporting to JUnit file 'JUnit_gcc_arm.xml'...
14:32:49 YottaModule: error -  [Errno 2] No such file or directory: '.\\module.json'
14:32:49 mbedgt: test suite report:
```