### PR TITLE
Bug-fix for #123: do not add baudrate multiple times to serial port definitions

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -677,8 +677,11 @@ def main_cli(opts, args, gt_instance_uuid=None):
                 continue
 
             if mbed_dev['platform_name'] == platform_name:
-                # We will force configuration specific baudrate
-                mbed_dev['serial_port'] = "%s:%d" % (mbed_dev['serial_port'], baudrate)
+                # We will force configuration specific baudrate by adding baudrate to serial port
+                # Only add baudrate decoration for serial port if it's not already there
+                # Format used by mbedhtrun: 'serial_port' = '<serial_port_name>:<baudrate>'
+                if not mbed_dev['serial_port'].endswith(str(baudrate)):
+                    mbed_dev['serial_port'] = "%s:%d" % (mbed_dev['serial_port'], baudrate)
                 mut = mbed_dev
                 muts_to_test.append(mbed_dev)
                 # Log on screen mbed device properties


### PR DESCRIPTION
Change:
* Serial port baudrate is doubled for multiple builds from test spec, see #123 
* This issue appears only when we are using multiple test sepc configurations or specify multiple yotta targets with -t switch

## Testing
Correct baudrate for second pass for `mbedgt: processing target 'K64F' toolchain 'GCC_ARM' compatible platforms...` build:
```
mbedgt --test-spec ts.json --config -v
mbedgt: detecting connected mbed-enabled devices...
mbedgt: detected 2 devices
        detected 'K64F' -> 'K64F[0]', console at 'COM218', mounted at 'E:', target id '0240000033514e450043500585d4003fe981000097969900'
        detected 'K64F' -> 'K64F[1]', console at 'COM220', mounted at 'G:', target id '0240000033514e45002e500585d4001ee981000097969900'
mbedgt: processing target 'K64F' toolchain 'ARM' compatible platforms...
mbedgt: using platform 'K64F' for test:
        mount_point = 'E:'
        target_id = '0240000033514e450043500585d4003fe981000097969900'
        serial_port = 'COM218:115200'
        daplink_version = '0241'
mbedgt: processing target 'K64F' toolchain 'GCC_ARM' compatible platforms...
mbedgt: using platform 'K64F' for test:
        mount_point = 'E:'
        target_id = '0240000033514e450043500585d4003fe981000097969900'
        serial_port = 'COM218:115200'
        daplink_version = '0241'
mbedgt: shuffle seed: 0.9265568155
mbedgt: no platform/target matching tests were found!
mbedgt: no target matching platforms were found!
mbedgt: completed in 0.05 sec
mbedgt: exited with code -110
````

With this issue on line 'serial_port = 'COM218:115200'' would look like this:
`serial_port = 'COM218:115200:115200'`.