### PR TITLE
Fixing stack trace when a bad test name is specified.

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -44,7 +44,7 @@ from mbed_greentea.mbed_greentea_dlm import greentea_update_kettle
 from mbed_greentea.mbed_greentea_dlm import greentea_clean_kettle
 from mbed_greentea.mbed_yotta_api import get_test_suite_properties
 from mbed_greentea.mbed_greentea_hooks import GreenteaHooks
-from mbed_greentea.tests_spec import TestBinary
+from mbed_greentea.tests_spec import TestSpec, TestBinary
 from mbed_greentea.mbed_target_info import get_platform_property
 
 from mbed_greentea.cmake_handlers import list_binaries_for_builds
@@ -96,7 +96,7 @@ def print_version(verbose=True):
 
 def create_filtered_test_list(ctest_test_list, test_by_names, skip_test, test_spec=None):
     """! Filters test case list (filtered with switch -n) and return filtered list.
-    @ctest_test_list List iof tests, originally from CTestTestFile.cmake in yotta module. Now comes from test specification
+    @ctest_test_list List of tests, originally from CTestTestFile.cmake in yotta module. Now comes from test specification
     @test_by_names Command line switch -n <test_by_names>
     @skip_test Command line switch -i <skip_test>
     @param test_spec Command line switch --test-spec <test_spec_filename>
@@ -141,7 +141,8 @@ def create_filtered_test_list(ctest_test_list, test_by_names, skip_test, test_sp
         gt_logger.gt_log_tab("note: see list of available test cases below")
         # Print available test suite names (binary names user can use with -n
         if test_spec:
-            list_binaries_for_builds(test_spec)
+            parsed_test_spec = TestSpec(test_spec)
+            list_binaries_for_builds(parsed_test_spec)
         else:
             list_binaries_for_targets()
     return filtered_ctest_test_list


### PR DESCRIPTION
If you specify an incorrect test name with the `-n` when using a test spec file, you get and `AttributeError` stack trace:

```
C:\m\proj>mbedgt -V --test-spec=test_spec.json -n bad-test-name
mbedgt: detecting connected mbed-enabled devices...
mbedgt: detected 1 device
        detected 'K64F' -> 'K64F[0]', console at 'COM238', mounted at 'D:', target id '0240000033514e450014500585d4004be981000097969900'
mbedgt: processing target 'K64F' toolchain 'GCC_ARM' compatible platforms...
mbedgt: using platform 'K64F' for test:
        target_id_mbed_htm = '0240000033514e450014500585d4004be981000097969900'
        daplink_hic_id = '97969900'
        mount_point = 'D:'
        daplink_automation_allowed = '0'
        daplink_daplink_mode = 'Interface'
        daplink_local_mods = '0'
        daplink_unique_id = '0240000033514e450014500585d4004be981000097969900'
        daplink_interface_crc = '0x33e2dd18'
        target_id = '0240000033514e450014500585d4004be981000097969900'
        serial_port = 'COM238:9600'
        target_id_usb_id = '0240000033514e450014500585d4004be981000097969900'
        platform_name = 'K64F'
        platform_name_unique = 'K64F[0]'
        daplink_git_sha = '34182e2cce4ca99073443ef29fbcfaab9e18caec'
        daplink_interface_version = '0241'
        daplink_auto_reset = '0'
        daplink_usb_interfaces = 'MSD, CDC, HID'
        daplink_version = '0241'
mbedgt: test case filter (specified with -n option)
mbedgt: invalid test case names (specified with '-n' option)
mbedgt: test name 'bad-test-name' not found in 'test_spec.json' (specified with --test-spec option)
        note: test case names are case sensitive
        note: see list of available test cases below
mbedgt: unexpected error:
        'str' object has no attribute 'get_test_builds'
Traceback (most recent call last):
  File "C:\Python27\Scripts\mbedgt-script.py", line 9, in <module>
    load_entry_point('mbed-greentea', 'console_scripts', 'mbedgt')()
  File "c:\users\bridan01\documents\dev\greentea\mbed_greentea\mbed_greentea_cli.py", line 345, in main
    cli_ret = main_cli(opts, args)
  File "c:\users\bridan01\documents\dev\greentea\mbed_greentea\mbed_greentea_cli.py", line 734, in main_cli
    filtered_ctest_test_list = create_filtered_test_list(test_list, opts.test_by_names, opts.skip_test, test_spec=opts.test_spec)
  File "c:\users\bridan01\documents\dev\greentea\mbed_greentea\mbed_greentea_cli.py", line 144, in create_filtered_test_list
    list_binaries_for_builds(test_spec)
  File "c:\users\bridan01\documents\dev\greentea\mbed_greentea\cmake_handlers.py", line 112, in list_binaries_for_builds
    test_builds = test_spec.get_test_builds()
AttributeError: 'str' object has no attribute 'get_test_builds'
```

The issue was the passed test spec filename in the `create_filtered_test_list` function was not being parsed before being passed to the `list_binaries_for_builds` function. I fixed this by parsing it first.