### PR TITLE
Add test_spec.json as default name for test spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,7 +514,7 @@ Above command will execute all tests for yotta module you are in, e.g. ```mbed-d
 
 # Test specification JSON formatted input
 
-Greentea originally only supports yotta artefacts. It assumes it is run inside a yotta module and gathers information from local file system. To make it generic for any other test artefacts we can support a test specification input. This specification can tell information like platform, tool chain, build artefacts path, test binaries, flash methods of test binaries to Greentea.
+Greentea originally only supports yotta artefacts. It assumes it is run inside a yotta module and gathers information from local file system. To make it generic for any other test artefacts we can support a test specification input. This specification can tell information like platform, toolchain, build artefacts path, test binaries, flash methods of test binaries to Greentea.
 Test specification is an interface which can be used by any build system or it can be created manually. Test specification interface was added to separate build system from test automation automation (Greentea).
 
 Changes:
@@ -523,11 +523,11 @@ Changes:
 
 ## Test specification formatted
 
-More detailed test specification format will be introduced in near future. In current form test specification is a dictionary with key-value pairs under "builds" entry where key is a build name and value is a dictionary with additional properties describing build itself. Build properties include platform name, toolchain used to compile interface chipa baudrate and list of test binaries.
+More detailed test specification format will be introduced in near future. In current form test specification is a dictionary with key-value pairs under "builds" entry where key is a build name and value is a dictionary with additional properties describing build itself. Build properties include platform name, toolchain used to compile, interface chip baudrate, and list of test binaries.
 
 ## Example of test specification file
 
-In below example there are two build defined:
+In the below example there are two builds defined:
 * Build `K64F-ARM` for Freescale `K64F` platform compiled with `ARMCC` compiler and
 * build `K64F-GCC` for Freescale `K64F` platform compiled with `GCC ARM` compiler.
 
@@ -584,7 +584,7 @@ In below examples we will use above test specification file.
 
 ### Command line usage
 
-When building your mbed projects with <build system> capable of returning test specification in our format you can directly call Greentea to execute tests or list available tests (`-l` / `--list` switch).
+When building your mbed projects with *build system* capable of returning test specification in our format you can directly call Greentea to execute tests or list available tests (`-l` / `--list` switch).
 
 #### Executing all tests
 
@@ -596,7 +596,7 @@ will pick up test specification and execute all tests in it.
 
 #### Cherry-pick tests
 
-* We will first tests we want to execute:
+* We will first list the tests we want to execute:
 
 Assuming that `test_spec.json` is in current directory:
 ```

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 # Table of contents
 
 * [Table of contents](#table-of-contents)
-* [Quickstart document](#quickstart-document)
 * [Introduction](#introduction)
+* [Quickstart document](#quickstart-document)
   * [mbed test tools collection](#mbed-test-tools-collection)
-  * [Additional documentation:](#additional-documentation)
+  * [Additional documentation](#additional-documentation)
   * [Supported operating systems](#supported-operating-systems)
 * [Getting started](#getting-started)
   * [End to end example](#end-to-end-example)
@@ -25,6 +25,12 @@
   * [Environment check](#environment-check)
   * [Building the mbed-drivers for yotta target target](#building-the-mbed-drivers-for-yotta-target-target)
 * [Testing](#testing)
+* [Test specification JSON formatted input](#test-specification-json-formatted-input)
+  * [Test specification formatted](#test-specification-formatted)
+  * [Example of test specification file](#example-of-test-specification-file)
+    * [Command line usage](#command-line-usage)
+      * [Executing all tests](#executing-all-tests)
+      * [Cherry-pick tests](#cherry-pick-tests)
 * [Using Greentea with new targets](#using-greentea-with-new-targets)
   * [Greentea and yotta targets](#greentea-and-yotta-targets)
   * [Prototyping support](#prototyping-support)
@@ -62,7 +68,7 @@ Please read [QUICKSTART.md](https://github.com/ARMmbed/greentea/blob/master/docs
 * [mbed-ls](https://github.com/ARMmbed/mbed-ls) - list all connected to host mbed compatible devices.
   * This application is also distributed as Python Package: [mbed-ls in PyPI](https://pypi.python.org/pypi/mbed-ls).
 
-## Additional documentation:
+## Additional documentation
 
 * [Quickstart document](https://github.com/ARMmbed/greentea/blob/master/docs/QUICKSTART.md)
 * Things you need to know [when you contribute](https://github.com/ARMmbed/greentea/blob/master/docs/CONTRIBUTING.md) to open source mbed test tools repositories.
@@ -505,6 +511,119 @@ $ mbedgt -V --target=frdm-k64f-gcc
 ```
 
 Above command will execute all tests for yotta module you are in, e.g. ```mbed-drivers```.
+
+# Test specification JSON formatted input
+
+Greentea originally only supports yotta artefacts. It assumes it is run inside a yotta module and gathers information from local file system. To make it generic for any other test artefacts we can support a test specification input. This specification can tell information like platform, tool chain, build artefacts path, test binaries, flash methods of test binaries to Greentea.
+Test specification is an interface which can be used by any build system or it can be created manually. Test specification interface was added to separate build system from test automation automation (Greentea).
+
+Changes:
+* New command line switch `--test-spec` is introduced. It is used to pass test specification file name to Greentea.
+* Existing command line switch `-t` together with `--test-spec` switch can be used to select build(s) by name which should be used for test runs. When no test specification is defined switch `-t` / `--target` behaves as usual: you can select yotta targets inside yotta module.
+
+## Test specification formatted
+
+More detailed test specification format will be introduced in near future. In current form test specification is a dictionary with key-value pairs under "builds" entry where key is a build name and value is a dictionary with additional properties describing build itself. Build properties include platform name, toolchain used to compile interface chipa baudrate and list of test binaries.
+
+## Example of test specification file
+
+In below example there are two build defined:
+* Build `K64F-ARM` for Freescale `K64F` platform compiled with `ARMCC` compiler and
+* build `K64F-GCC` for Freescale `K64F` platform compiled with `GCC ARM` compiler.
+
+```json
+{
+    "builds": {
+        "K64F-ARM": {
+            "platform": "K64F",
+            "toolchain": "ARM",
+            "base_path": "./.build/K64F/ARM",
+            "baud_rate": 115200,
+            "tests": {
+                "mbed-drivers-test-generic_tests":{
+                    "binaries":[
+                        {
+                            "binary_type": "bootable",
+                            "path": "./.build/K64F/ARM/mbed-drivers-test-generic_tests.bin"
+                        }
+                    ]
+                },
+                "mbed-drivers-test-c_strings":{
+                    "binaries":[
+                        {
+                            "binary_type": "bootable",
+                            "path": "./.build/K64F/ARM/mbed-drivers-test-c_strings.bin"
+                        }
+                    ]
+                }
+            }
+        },
+        "K64F-GCC": {
+            "platform": "K64F",
+            "toolchain": "GCC_ARM",
+            "base_path": "./.build/K64F/GCC_ARM",
+            "baud_rate": 115200,
+            "tests": {
+                "mbed-drivers-test-generic_tests":{
+                    "binaries":[
+                        {
+                            "binary_type": "bootable",
+                            "path": "./.build/K64F/GCC_ARM/mbed-drivers-test-generic_tests.bin"
+                        }
+                    ]
+                }
+
+            }
+        }
+
+    }
+}
+```
+
+In below examples we will use above test specification file.
+
+### Command line usage
+
+When building your mbed projects with <build system> capable of returning test specification in our format you can directly call Greentea to execute tests or list available tests (`-l` / `--list` switch).
+
+#### Executing all tests
+
+Assuming that `test_spec.json` is in current directory:
+```
+$ mbedgt -VS
+```
+will pick up test specification and execute all tests in it.
+
+#### Cherry-pick tests
+
+* We will first tests we want to execute:
+
+Assuming that `test_spec.json` is in current directory:
+```
+$ mbedgt -l
+```
+```
+mbedgt: using 'test_spec.json' from current directory!
+mbedgt: available tests for built 'K64F-ARM', location './.build/K64F/ARM'
+        test 'mbed-drivers-test-generic_tests'
+        test 'mbed-drivers-test-c_strings'
+mbedgt: available tests for built 'K64F-GCC', location './.build/K64F/GCC_ARM'
+        test 'mbed-drivers-test-generic_tests'
+```
+
+* Now we can select test case(s) by name(s) using `-n` switch:
+
+Below command will execute tests with name `mbed-drivers-test-generic_tests` from all builds in build specification:
+```
+$ mbedgt -V -n mbed-drivers-test-generic_tests
+```
+
+Below command will execute tests with name `mbed-drivers-test-generic_tests` only from build `K64F-ARM` in build specification:
+```
+$ mbedgt -V -n mbed-drivers-test-generic_tests -t K64F-ARM
+```
+
+Note: you can use comman '`,`' to separate test names (switch `-n`) and build names (switch `-t`)
 
 # Using Greentea with new targets
 When prototyping or developing new port you will find yourself in a situation where your yotta modules are not published (especially targets) and you still want to use Greentea.

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -99,7 +99,7 @@ def create_filtered_test_list(ctest_test_list, test_by_names, skip_test, test_sp
     @ctest_test_list List iof tests, originally from CTestTestFile.cmake in yotta module. Now comes from test specification
     @test_by_names Command line switch -n <test_by_names>
     @skip_test Command line switch -i <skip_test>
-    @param test_spec Command line switch --test-spec <test_spec_filename>
+    @param test_spec Test specification object loaded with --test-spec switch
     @return
     """
     filtered_ctest_test_list = ctest_test_list
@@ -134,9 +134,12 @@ def create_filtered_test_list(ctest_test_list, test_by_names, skip_test, test_sp
         gt_logger.gt_log_warn("invalid test case names (specified with '%s' option)"% opt_to_print)
         for test_name in invalid_test_names:
             if test_spec:
-                gt_logger.gt_log_warn("test name '%s' not found in '%s' (specified with --test-spec option)"% (gt_logger.gt_bright(test_name), gt_logger.gt_bright(test_spec)))
+                test_spec_name = test_spec.test_spec_filename
+                gt_logger.gt_log_warn("test name '%s' not found in '%s' (specified with --test-spec option)"% (gt_logger.gt_bright(test_name),
+                    gt_logger.gt_bright(test_spec_name)))
             else:
-                gt_logger.gt_log_warn("test name '%s' not found in CTestTestFile.cmake (specified with '%s' option)"% (gt_logger.gt_bright(test_name), opt_to_print))
+                gt_logger.gt_log_warn("test name '%s' not found in CTestTestFile.cmake (specified with '%s' option)"% (gt_logger.gt_bright(test_name),
+                    opt_to_print))
         gt_logger.gt_log_tab("note: test case names are case sensitive")
         gt_logger.gt_log_tab("note: see list of available test cases below")
         # Print available test suite names (binary names user can use with -n
@@ -731,7 +734,8 @@ def main_cli(opts, args, gt_instance_uuid=None):
                 continue
 
             test_list = test_build.get_tests()
-            filtered_ctest_test_list = create_filtered_test_list(test_list, opts.test_by_names, opts.skip_test, test_spec=opts.test_spec)
+
+            filtered_ctest_test_list = create_filtered_test_list(test_list, opts.test_by_names, opts.skip_test, test_spec=test_spec)
 
             gt_logger.gt_log("running %d test%s for platform '%s' and toolchain '%s'"% (
                 len(filtered_ctest_test_list),

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -364,14 +364,28 @@ def get_test_spec(opts):
     """
     test_spec = None
 
+    # Check if test_spec.json file exist, if so we will pick it up as default file and load it
+    test_spec_file_name = opts.test_spec
+
+    # Note: test_spec.json will have higher priority than module.json file
+    #       so if we are inside directory with module.json and test_spec.json we will use test spec file
+    #       instead of using yotta's module.json file
+
     if opts.test_spec:
-        # Test spec defined from command line
-        test_spec = TestSpec(opts.test_spec)
+        gt_logger.gt_log("test specification file '%s' (specified with --test-spec option)"% opts.test_spec)
+    elif os.path.exists('test_spec.json'):
+        test_spec_file_name = 'test_spec.json'
+
+    if test_spec_file_name:
+        # Test spec from command line (--test-spec) or default test_spec.json will be used
+        gt_logger.gt_log("using '%s' from current directory!"% test_spec_file_name)
+        test_spec = TestSpec(test_spec_file_name)
         if opts.list_binaries:
             list_binaries_for_builds(test_spec)
             return None, 0
     elif os.path.exists('module.json'):
         # If inside yotta module load module data and generate test spec
+        gt_logger.gt_log("using 'module.json' from current directory!")
         if opts.list_binaries:
             # List available test binaries (names, no extension)
             list_binaries_for_targets()
@@ -379,6 +393,6 @@ def get_test_spec(opts):
         else:
             test_spec = get_test_spec_from_yt_module(opts)
     else:
-        gt_logger.gt_log_err("Greentea should be run inside a Yotta module or --test-spec switch should be used.")
+        gt_logger.gt_log_err("greentea should be run inside a Yotta module or --test-spec switch should be used.")
         return None, -1
     return test_spec, 0

--- a/mbed_greentea/tests_spec.py
+++ b/mbed_greentea/tests_spec.py
@@ -240,7 +240,7 @@ class TestSpec:
         :return:
         """
         self.__target_test_spec = {}
-        if self.test_spec_filename:
+        if test_spec_filename:
             self.test_spec_filename = test_spec_filename
             self.load(self.test_spec_filename)
 

--- a/mbed_greentea/tests_spec.py
+++ b/mbed_greentea/tests_spec.py
@@ -239,8 +239,9 @@ class TestSpec:
         :return:
         """
         self.__target_test_spec = {}
-        if test_spec_filename:
-            self.load(test_spec_filename)
+        self.test_spec_filename = test_spec_filename
+        if self.test_spec_filename:
+            self.load(self.test_spec_filename)
 
     def load(self, test_spec_filename):
         """
@@ -256,6 +257,7 @@ class TestSpec:
             print "TestSpec::load('%s')"% test_spec_filename, str(e)
             return False
 
+        self.test_spec_filename = test_spec_filename
         return True
 
     def parse(self, spec):

--- a/mbed_greentea/tests_spec.py
+++ b/mbed_greentea/tests_spec.py
@@ -231,6 +231,7 @@ class TestSpec:
     Test specification. Contains Builds.
     """
     KW_BUILDS = "builds"
+    test_spec_filename = 'runtime_load'
 
     def __init__(self, test_spec_filename=None):
         """
@@ -239,15 +240,15 @@ class TestSpec:
         :return:
         """
         self.__target_test_spec = {}
-        self.test_spec_filename = test_spec_filename
         if self.test_spec_filename:
+            self.test_spec_filename = test_spec_filename
             self.load(self.test_spec_filename)
 
     def load(self, test_spec_filename):
         """
-        Load test spec dirrectly from file
+        Load test spec directly from file
 
-        :param test_spec_filename: Name of JSON file with TestSpec
+        :param test_spec_filename: Name of JSON file with TestSpec to load
         :return: Treu if load was successful
         """
         try:
@@ -272,9 +273,6 @@ class TestSpec:
             mandatory_keys = [TestBuild.KW_PLATFORM, TestBuild.KW_TOOLCHAIN,
                               TestBuild.KW_BAUD_RATE,
                               TestBuild.KW_BUILD_BASE_PATH]
-            #print set(mandatory_keys)
-            #print set(build.keys())
-            #print set(mandatory_keys).issubset(set(build.keys()))
             assert set(mandatory_keys).issubset(set(build.keys())), \
                 "Build spec should contain keys [%s]. It has [%s]" % (",".join(mandatory_keys), ",".join(build.keys()))
             platform = build[TestBuild.KW_PLATFORM]


### PR DESCRIPTION
## Description

Currently after we've added `--test-spec` switch users have to explicitly declare it after building with <build system> which outputs test spec. So:
* I've updated [README.md](https://github.com/ARMmbed/greentea/tree/devel_test_spec_pickup#test-specification-json-formatted-input) with some test specification info.
* if `test_spec.json` (which is default name of test spec returned by <build system>) exist in directory in which we are calling Greentea (`mbedgt` command) we will pick it up as default test spec. This action will be equal to calling Greentea with explicit `--test-spec test_spec.json` switch.
* If `module.json` exist in directory we will assume this is a yotta module and act accordingly.
* If both `module.json` and `test_spec.json` exist we will give priority to `test_spec.json` file and assume use wants to execute tests from default test specification.
* There is no change to `--test-spec <filename.json>` it still picks up test spec and executes tests from it.
* New functionality works with switches like `-V`, `-S` or `-l`/`--list`.
*  Bug-fix: We were loading a `None` (TestSpec.load(None)) to test_spec_filename  ctro parameter when `TestSpec()` ctor was called without parameters.

## Example
```
$ ls
test_spec.json
...
```
```
$ mbedgt -l
mbedgt: using 'test_spec.json' from current directory!
mbedgt: available tests for built 'K64F-GCC_ARM', location '.\.build/tests\K64F\GCC_ARM'
        test 'TESTS-integration-threaded_blinky'
        test 'TESTS-integration-basic'
```
This is equal to executing `mbedgt -l --test-spec test_spec.json`.

## Other
Note: `test_spec.json` will have higher priority than module.json file so if we are inside directory with module.json and test_spec.json we will use test spec file instead of using yotta's module.json file.