### PR TITLE
Greentea should check for yotta target first from local .yotta.json file

### DIFF
--- a/mbed_greentea/mbed_common_api.py
+++ b/mbed_greentea/mbed_common_api.py
@@ -48,6 +48,13 @@ def run_cli_process(cmd):
     @param cmd Command to execute
     @return Tuple of (stdout, stderr, returncode)
     """
-    p = Popen(cmd, stdout=PIPE, stderr=PIPE)
-    _stdout, _stderr = p.communicate()
+    try:
+        p = Popen(cmd, stdout=PIPE, stderr=PIPE)
+        _stdout, _stderr = p.communicate()
+    except OSError as e:
+        print "mbedgt: [ret=%d] Command: %s"% (int(ret), p.returncode)
+        print str(e)
+        print "mbedgt: traceback..."
+        print e.child_traceback
+        return str(), str(), -1
     return _stdout, _stderr, p.returncode

--- a/test/mbed_gt_target_info.py
+++ b/test/mbed_gt_target_info.py
@@ -18,7 +18,6 @@ limitations under the License.
 
 import unittest
 
-import json
 from mock import patch
 from mbed_greentea import mbed_target_info
 

--- a/test/mbed_gt_target_info.py
+++ b/test/mbed_gt_target_info.py
@@ -17,6 +17,8 @@ limitations under the License.
 """
 
 import unittest
+
+import json
 from mock import patch
 from mbed_greentea import mbed_target_info
 
@@ -253,6 +255,57 @@ mbed-gcc 1.1.0
         r = mbed_target_info.get_mbed_target_from_current_dir()
         self.assertEqual('frdm-k64f-gcc', r)
 
+    def test_parse_yotta_json_for_build_name(self):
+        self.assertEqual('frdm-k64f-gcc', mbed_target_info.parse_yotta_json_for_build_name(
+            {
+              "build": {
+                "target": "frdm-k64f-gcc,*",
+                "targetSetExplicitly": True
+              }
+            }
+        ))
 
+        self.assertEqual('x86-linux-native', mbed_target_info.parse_yotta_json_for_build_name(
+            {
+              "build": {
+                "target": "x86-linux-native,*",
+                "targetSetExplicitly": True
+              }
+            }
+        ))
+
+        self.assertEqual('frdm-k64f-gcc', mbed_target_info.parse_yotta_json_for_build_name(
+            {
+              "build": {
+                "target": "frdm-k64f-gcc,*"
+              }
+            }
+        ))
+
+        self.assertEqual('frdm-k64f-gcc', mbed_target_info.parse_yotta_json_for_build_name(
+            {
+              "build": {
+                "target": "frdm-k64f-gcc"
+              }
+            }
+        ))
+
+        self.assertEqual(None, mbed_target_info.parse_yotta_json_for_build_name(
+            {
+                "build": {
+                }
+            }
+        ))
+
+        self.assertEqual(None, mbed_target_info.parse_yotta_json_for_build_name(
+            {
+              "BUILD": {
+                  "target": "frdm-k64f-gcc,*",
+                  "targetSetExplicitly": True
+              }
+            }
+        ))
+
+        
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Rationale
When yotta is not installed we still should be able to check currently set 

## Changes
* Add parsing function for `'yotta.json`.
* Add proper unit tests.
* Fixed not handled `OSError` in `run_cli_process` function.

## What we will fix
Use case is like this: On a host without yotta installed, for example think CI slave we still would like to fetch `yotta target` information passed there with the build. This information is originally checked with `$ yotta --plain target` command. We would like to avoid command line execution and parse `.yotta.json` file in root of yotta module.
This will even stronger decouple Greentea from build system which now is optional.

Note: This is a part of an effort to completely decouple build system from Greentea so we can use test specification instead.

## Error traceback
```
mbedgt: using 'module.json' from current directory!
mbedgt: checking for yotta target in current directory
	reason: no --target switch set
mbedgt: checking yotta target in current directory
	calling yotta: yotta --plain target
mbedgt: unexpected error:
	[Errno 2] No such file or directory
Traceback (most recent call last):
  File "/venv/bin/mbedgt", line 11, in <module>
    sys.exit(main())
  File "/venv/local/lib/python2.7/site-packages/mbed_greentea/mbed_greentea_cli.py", line 348, in main
    cli_ret = main_cli(opts, args)
  File "/venv/local/lib/python2.7/site-packages/mbed_greentea/mbed_greentea_cli.py", line 568, in main_cli
    test_spec, ret = get_test_spec(opts)
  File "/venv/local/lib/python2.7/site-packages/mbed_greentea/mbed_test_api.py", line 394, in get_test_spec
    test_spec = get_test_spec_from_yt_module(opts)
  File "/venv/local/lib/python2.7/site-packages/mbed_greentea/mbed_yotta_api.py", line 139, in get_test_spec_from_yt_module
    current_target = get_mbed_target_from_current_dir()
  File "/venv/local/lib/python2.7/site-packages/mbed_greentea/mbed_target_info.py", line 139, in get_mbed_target_from_current_dir
    _stdout, _stderr, _ret = get_mbed_target_call_yotta_target()
  File "/venv/local/lib/python2.7/site-packages/mbed_greentea/mbed_target_info.py", line 131, in get_mbed_target_call_yotta_target
    _stdout, _stderr, _ret = run_cli_process(cmd)
  File "/venv/local/lib/python2.7/site-packages/mbed_greentea/mbed_common_api.py", line 51, in run_cli_process
    p = Popen(cmd, stdout=PIPE, stderr=PIPE)
  File "/usr/lib/python2.7/subprocess.py", line 710, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1335, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```
