### PR TITLE
#134: TypeError caused by incorrect formatting of error message in run_host_test function

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -404,6 +404,7 @@ def run_test_thread(test_result_queue, test_queue, opts, mut, build, build_path,
         if isinstance(host_test_result, int):
             # int(host_test_result) > 0 - Call to mbedhtrun failed
             # int(host_test_result) < 0 - Something went wrong while executing mbedhtrun
+            gt_logger.gt_log_err("run_test_thread.run_host_test() failed, aborting...")
             break
 
         # If execution was successful 'run_host_test' return tuple with results
@@ -592,7 +593,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
         if isinstance(host_test_result, int):
             # int(host_test_result) > 0 - Call to mbedhtrun failed
             # int(host_test_result) < 0 - Something went wrong while executing mbedhtrun
-            return int(host_test_result)
+            return host_test_result
 
         # If execution was successful 'run_host_test' return tuple with results
         single_test_result, single_test_output, single_testduration, single_timeout, result_test_cases, test_cases_summary = host_test_result
@@ -741,7 +742,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
                 if isinstance(host_test_result, int):
                     # int(host_test_result) > 0 - Call to mbedhtrun failed
                     # int(host_test_result) < 0 - Something went wrong while executing mbedhtrun
-                    return int(host_test_result)
+                    return host_test_result
 
                 # If execution was successful 'run_host_test' return tuple with results
                 single_test_result, single_test_output, single_testduration, single_timeout, result_test_cases, test_cases_summary = host_test_result

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -401,9 +401,12 @@ def run_test_thread(test_result_queue, test_queue, opts, mut, build, build_path,
                                          verbose=verbose)
 
         # Some error in htrun, abort test execution
-        if host_test_result < 0:
+        if isinstance(host_test_result, int):
+            # int(host_test_result) > 0 - Call to mbedhtrun failed
+            # int(host_test_result) < 0 - Something went wrong while executing mbedhtrun
             break
 
+        # If execution was successful 'run_host_test' return tuple with results
         single_test_result, single_test_output, single_testduration, single_timeout, result_test_cases, test_cases_summary = host_test_result
         test_result = single_test_result
 
@@ -585,6 +588,13 @@ def main_cli(opts, args, gt_instance_uuid=None):
                                          enum_host_tests_path=enum_host_tests_path,
                                          verbose=opts.verbose_test_result_only)
 
+        # Some error in htrun, abort test execution
+        if isinstance(host_test_result, int):
+            # int(host_test_result) > 0 - Call to mbedhtrun failed
+            # int(host_test_result) < 0 - Something went wrong while executing mbedhtrun
+            return int(host_test_result)
+
+        # If execution was successful 'run_host_test' return tuple with results
         single_test_result, single_test_output, single_testduration, single_timeout, result_test_cases, test_cases_summary = host_test_result
         status = TEST_RESULTS.index(single_test_result) if single_test_result in TEST_RESULTS else -1
         return (status)
@@ -727,6 +737,13 @@ def main_cli(opts, args, gt_instance_uuid=None):
                                                  enum_host_tests_path=enum_host_tests_path,
                                                  verbose=True)
 
+                # Some error in htrun, abort test execution
+                if isinstance(host_test_result, int):
+                    # int(host_test_result) > 0 - Call to mbedhtrun failed
+                    # int(host_test_result) < 0 - Something went wrong while executing mbedhtrun
+                    return int(host_test_result)
+
+                # If execution was successful 'run_host_test' return tuple with results
                 single_test_result, single_test_output, single_testduration, single_timeout, result_test_cases, test_cases_summary = host_test_result
                 status = TEST_RESULTS.index(single_test_result) if single_test_result in TEST_RESULTS else -1
                 if single_test_result != TEST_RESULT_OK:

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -73,6 +73,11 @@ TEST_RESULT_MAPPING = {"success" : TEST_RESULT_OK,
                        }
 
 
+# This value is used to tell caller than run_host_test function failed while invoking mbedhtrun
+# Just a value greater than zero
+RUN_HOST_TEST_POPEN_ERROR = 1729
+
+
 def get_test_result(output):
     """! Parse test 'output' data
     @details If test result not found returns by default TEST_RESULT_TIMEOUT value
@@ -196,7 +201,7 @@ def run_host_test(image_path,
     p = run_command(cmd)
     if not p:
         # int value > 0 notifies caller that starting of host test process failed
-        return 1729
+        return RUN_HOST_TEST_POPEN_ERROR
 
     for line in iter(p.stdout.readline, b''):
         htrun_output += line


### PR DESCRIPTION
This is a response for #134 

Changes:
* New `int` result handler for calles to `run_host_test`
* `run_host_test` function can now return integer values if there is an issue.
* Better exception handler for `run_host_test.run_command()` function.
* `run_host_test.run_command()` will return None if process can't be executed.
* Minor refactoring.

Now if command fails we will see:
```
mbedgt: mbed-host-test-runner: started
mbedgt: run_host_test.run_command(['mbedhtrun', '-d', 'E:', '-p', u'COM218:9600', '-f', u'".\\build\\frdm-k64f-gcc\\test\\mbed-drivers-test-generic_tests.bin"', '-C', '4', '-c', 'shell', '-m', 'K64F', '-t', '0240000033514e450043500585d4003fe981000097969900', '-e', '"./test/host_tests"']) failed!
        [Error 2] The system cannot find the file specified
```