### PR TITLE
Add simple 'test-name-prefix*' filter to filter test cases with common prefix name

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -102,6 +102,20 @@ def create_filtered_test_list(ctest_test_list, test_by_names, skip_test, test_sp
     @param test_spec Test specification object loaded with --test-spec switch
     @return
     """
+
+    def filter_names_by_prefix(test_case_name_list, prefix_name):
+        """!
+        @param test_case_name_list List of all test cases
+        @param prefix_name Prefix of test name we are looking for
+        @result Set with names of test names starting with 'prefix_name'
+        """
+        result = list()
+        print
+        for test_name in test_case_name_list:
+            if test_name.startswith(prefix_name):
+                result.append(test_name)
+        return result
+
     filtered_ctest_test_list = ctest_test_list
     test_list = None
     invalid_test_names = []
@@ -113,7 +127,12 @@ def create_filtered_test_list(ctest_test_list, test_by_names, skip_test, test_sp
         gt_logger.gt_log("test case filter (specified with -n option)")
 
         for test_name in test_list:
-            if test_name not in ctest_test_list:
+            if test_name.endswith('*'):
+                # This 'star-sufix' filter allows users to filter tests with fixed prefixes
+                # Example: -n 'TESTS-mbed_drivers* will filter all test cases with name starting with 'TESTS-mbed_drivers'
+                for test_name_filtered in filter_names_by_prefix(ctest_test_list.keys(), test_name[:-1]):
+                    filtered_ctest_test_list[test_name_filtered] = ctest_test_list[test_name_filtered]
+            elif test_name not in ctest_test_list:
                 invalid_test_names.append(test_name)
             else:
                 gt_logger.gt_log_tab("test filtered in '%s'"% gt_logger.gt_bright(test_name))


### PR DESCRIPTION
When using Greentea switch `-n` and putting `*` at the end of test suite name filter will run to filter in all test suite names starting with string before `*`.

## Example usage:
1) Filter all tests with names starting with 'mbed-drivers-t', e.g.:
* tests-mbed_drivers-ticker
* tests-mbed_drivers-ticker_2
* tests-mbed_drivers-ticker_3
* tests-mbed_drivers-timeout

```
$ mbedgt -VS -n mbed-drivers-t*
```

2) Filter all tests with names starting with 'mbed-drivers-t' and test case
'tests-mbed_drivers-rtc', e.g:
* tests-mbed_drivers-rtc
* tests-mbed_drivers-ticker
* tests-mbed_drivers-ticker_2
* tests-mbed_drivers-ticker_3
* tests-mbed_drivers-timeout

```
$ mbedgt -VS -n mbed-drivers-t*,tests-mbed_drivers-rtc
```

```
mbedgt: test suite report:
+--------------+---------------+-----------------------------+--------+--------------------+-------------+
| target       | platform_name | test suite                  | result | elapsed_time (sec) | copy_method |
+--------------+---------------+-----------------------------+--------+--------------------+-------------+
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-rtc      | OK     | 21.53              | shell       |
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-ticker   | OK     | 22.04              | shell       |
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-ticker_2 | OK     | 21.99              | shell       |
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-ticker_3 | OK     | 21.98              | shell       |
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-timeout  | OK     | 22.01              | shell       |
+--------------+---------------+-----------------------------+--------+--------------------+-------------+
mbedgt: test suite results: 5 OK
mbedgt: test case report:
+--------------+---------------+-----------------------------+-----------------------+--------+--------+--------+--------------------+
| target       | platform_name | test suite                  | test case             | passed | failed | result | elapsed_time (sec) |
+--------------+---------------+-----------------------------+-----------------------+--------+--------+--------+--------------------+
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-rtc      | RTC strftime          | 1      | 0      | OK     | 10.14              |
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-ticker   | Timers: 2 x tickers   | 1      | 0      | OK     | 11.15              |
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-ticker_2 | Timers: 1x ticker     | 1      | 0      | OK     | 11.16              |
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-ticker_3 | Timers: 2x callbacks  | 1      | 0      | OK     | 11.15              |
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-timeout  | Timers: toggle on/off | 1      | 0      | OK     | 11.15              |
+--------------+---------------+-----------------------------+-----------------------+--------+--------+--------+--------------------+
mbedgt: test case results: 5 OK
mbedgt: completed in 109.65 sec
```