### PR TITLE
Fixing issues when multiple test builds exist

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -28,6 +28,7 @@ from Queue import Queue
 from threading import Thread
 
 
+from mbed_greentea.mbed_test_api import get_test_build_properties
 from mbed_greentea.mbed_test_api import get_test_spec
 from mbed_greentea.mbed_test_api import run_host_test
 from mbed_greentea.mbed_test_api import log_mbed_devices_properties
@@ -42,7 +43,6 @@ from mbed_greentea.mbed_greentea_dlm import GREENTEA_KETTLE_PATH
 from mbed_greentea.mbed_greentea_dlm import greentea_get_app_sem
 from mbed_greentea.mbed_greentea_dlm import greentea_update_kettle
 from mbed_greentea.mbed_greentea_dlm import greentea_clean_kettle
-from mbed_greentea.mbed_yotta_api import get_test_suite_properties
 from mbed_greentea.mbed_greentea_hooks import GreenteaHooks
 from mbed_greentea.tests_spec import TestBinary
 from mbed_greentea.mbed_target_info import get_platform_property
@@ -768,7 +768,6 @@ def main_cli(opts, args, gt_instance_uuid=None):
                 status = TEST_RESULTS.index(single_test_result) if single_test_result in TEST_RESULTS else -1
                 if single_test_result != TEST_RESULT_OK:
                     test_exec_retcode += 1
-                continue
 
             test_list = test_build.get_tests()
 
@@ -887,8 +886,12 @@ def main_cli(opts, args, gt_instance_uuid=None):
         if opts.report_junit_file_name:
             gt_logger.gt_log("exporting to JUnit file '%s'..."% gt_logger.gt_bright(opts.report_junit_file_name))
             # This test specification will be used by JUnit exporter to populate TestSuite.properties (useful meta-data for Viewer)
-            junit_test_spec = test_spec if opts.test_spec else None
-            junit_report = exporter_testcase_junit(test_report, test_suite_properties = get_test_suite_properties(test_spec=junit_test_spec))
+            test_suite_properties = {}
+            for target_name in test_report:
+                test_build_properties = get_test_build_properties(test_spec, target_name)
+                if test_build_properties:
+                    test_suite_properties[target_name] = test_build_properties
+            junit_report = exporter_testcase_junit(test_report, test_suite_properties = test_suite_properties)
             with open(opts.report_junit_file_name, 'w') as f:
                 f.write(junit_report)
         if opts.report_text_file_name:

--- a/mbed_greentea/mbed_report_api.py
+++ b/mbed_greentea/mbed_report_api.py
@@ -17,7 +17,6 @@ limitations under the License.
 Author: Przemyslaw Wirkus <Przemyslaw.wirkus@arm.com>
 """
 
-
 def export_to_file(file_name, payload):
     """! Simple file dump used to store reports on disk
     @param file_name Report file name (with path if needed)
@@ -133,7 +132,6 @@ def exporter_testcase_text(test_result_ext, test_suite_properties=None):
         pt.align[col] = "l"
     pt.padding_width = 1 # One space between column edges and contents (default)
 
-    # ym_name = test_suite_properties.get('name', 'unknown')
     result_testcase_dict = {}   # Used to print test case results
 
     for target_name in sorted(test_result_ext):
@@ -183,16 +181,11 @@ def exporter_testcase_text(test_result_ext, test_suite_properties=None):
 def exporter_testcase_junit(test_result_ext, test_suite_properties=None):
     """! Export test results in JUnit XML compliant format
     @param test_result_ext Extended report from Greentea
-    @param test_suite_properties Data from yotta module.json file
+    @param test_spec Dictionary of test build names to test suite properties
     @details This function will import junit_xml library to perform report conversion
     @return String containing Junit XML formatted test result output
     """
     from junit_xml import TestSuite, TestCase
-
-    # Only check test suite properties if argument is valid
-    ym_name = 'unknown'
-    if test_suite_properties:
-        ym_name = test_suite_properties.get('name', 'unknown')
 
     test_suites = []
 
@@ -233,7 +226,7 @@ def exporter_testcase_junit(test_result_ext, test_suite_properties=None):
                 except UnicodeDecodeError as e:
                     print "exporter_testcase_junit:", str(e)
 
-                tc_class = ym_name + '.' + target_name + '.' + test_suite_name
+                tc_class = target_name + '.' + test_suite_name
                 tc = TestCase(tc_name, tc_class, duration, tc_stdout, tc_stderr)
                 
                 if result_text == 'FAIL':
@@ -243,8 +236,9 @@ def exporter_testcase_junit(test_result_ext, test_suite_properties=None):
 
                 test_cases.append(tc)
 
-            ts_name = ym_name + '.' + target_name
-            ts = TestSuite(ts_name, test_cases, properties=test_suite_properties)
+            ts_name = target_name
+            test_build_properties = test_suite_properties[target_name] if target_name in test_suite_properties else None
+            ts = TestSuite(ts_name, test_cases, properties=test_build_properties)
             test_suites.append(ts)
 
     return TestSuite.to_xml_string(test_suites)

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -461,3 +461,15 @@ def get_test_spec(opts):
         gt_logger.gt_log_err("greentea should be run inside a Yotta module or --test-spec switch should be used.")
         return None, -1
     return test_spec, 0
+
+def get_test_build_properties(test_spec, test_build_name):
+    result = dict()
+    test_builds = test_spec.get_test_builds(filter_by_names=[test_build_name])
+    if test_builds:
+        test_build = test_builds[0]
+        result['name'] = test_build.get_name()
+        result['toolchain'] = test_build.get_toolchain()
+        result['target'] = test_build.get_platform()
+        return result
+    else:
+        return None

--- a/mbed_greentea/mbed_yotta_api.py
+++ b/mbed_greentea/mbed_yotta_api.py
@@ -191,31 +191,3 @@ def get_test_spec_from_yt_module(opts):
             tb.add_test(name, t)
 
     return test_spec
-
-def get_test_suite_properties(test_spec=None):
-    """ Read data from module.json to help reporter do its job
-
-    If test_spec provided function will arrange JUNit test suite properties in a way report viewer can take advantage of it.
-    Test suite properties should be compatible with mbedmicro/mbed properties.
-    If no test_spec we will use module.json data as properties for Test Suite.
-
-    @param test_spec Test specification object (class TestSpec) used with --test-spec switch.
-                     This is used to add extra properties to JUnit test suite report.
-    @return Stuff in format of yotta module.json
-    """
-
-    if test_spec:
-        result = dict()
-        first_test_spec = test_spec.get_test_builds()
-        if first_test_spec:
-            first_build = first_test_spec[0]
-            result['name'] = first_build.get_name()
-            result['toolchain'] = first_build.get_toolchain()
-            result['target'] = first_build.get_platform()
-            return result
-    else:
-        ### Read yotta module basic information
-        yotta_module = YottaModule()
-        if yotta_module.init():
-            return yotta_module.get_data()
-    return None


### PR DESCRIPTION
This PR addresses a few issues that arise when multiple test builds are present in a test spec.

## Changes
- Properly sets test build properties in the JUnit XML report. Fixes issue #138.
- Fixes issue where only one test build isexecuted even if no test build filter is applied.
- Removes yotta module name prefix from the test report
  - If this needs to be added back, then I'd propose adding the yotta module name to the "test build name", so it would look like `<yotta module name>.<yotta target name>`

@PrzemekWirkus please review
@mazimkhan, @adbridge, FYI