### PR TITLE
Modify host_tests crawler to work with smaller test_spec.json with ab…

### DIFF
--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -159,10 +159,10 @@ def run_host_test(image_path,
         try:
             binary_path_norm = os.path.normpath(binary_path)
             # Finding path to binary tests group
-            # Removing ,build/tests/PLATFORM/TOOLCHAIN
-            # [4:  -> .build\\tests\\K64F\\GCC_ARM
-            # :-2] -> \\queue\\TESTS-mbedmicro-rtos-mbed-queue.bin
-            host_tests_path = ['.'] + binary_path_norm.split(os.sep)[4:-level] + ['host_tests']
+            # From: "...\\.build\\tests\\K64F\\GCC_ARM\\TESTS\\mbedmicro-net\\udp_echo_client\\TESTS-mbedmicro-net-udp_echo_client.bin"
+            # To:   ".\\TESTS\\mbedmicro-net\\host_tests" or
+            # To:   ".\\TESTS\\host_tests"
+            host_tests_path = ['.'] + binary_path_norm.split(os.sep)[-4:-level] + ['host_tests']
             host_tests_path = os.path.join(*host_tests_path)
         except Exception as e:
             gt_logger.gt_log_warn("there was a problem while looking for host_tests directory")


### PR DESCRIPTION
…solute path in `binaries::path`.

## Description
This change simplifies how we use path crawler which is dump but allows us to check against default `host_tests` directory in test group or directly in `TESTS` directory.
* Test group is in `./TESTS/test-group/host_tests`
* TESTS directory:`./TESTS/host_tests`

## Testing
```json
{
  "builds": {
    "K64F-GCC_ARM": {
      "binary_type": "bootable", 
      "tests": {
        "TESTS-mbedmicro-net-udp_echo_client": {
          "binaries": [
            {
              "path": "c:\\Work\\mbed-os\\.build\\tests\\K64F\\GCC_ARM\\TESTS\\mbedmicro-net\\udp_echo_client\\TESTS-mbedmicro-net-udp_echo_client.bin"
            }
          ]
        }
      }, 
      "toolchain": "GCC_ARM", 
      "base_path": "c:\\Work\\mbed-os\\.build/tests\\K64F\\GCC_ARM", 
      "baud_rate": 9600, 
      "platform": "K64F"
    }
  }
}
```

```
mbedgt: selecting test case observer...
        calling mbedhtrun: mbedhtrun -d E: -p COM228:9600 -f "c:\Work\mbed-os\.build\tests\K64F\GCC_ARM\TESTS\mbedmicro-net\udp_echo_client\TESTS-mbedmicro-net-udp_echo_client.bin" -C 4 -c shell -m K64F -t 0240000029304e450038500878a3003cf131000097969900 -e ".\TESTS\mbedmicro-net\host_tests"
```

```
$ mbedhtrun 
  -d E: 
  -p COM228:9600 
  -f "c:\Work\mbed-os\.build\tests\K64F\GCC_ARM\TESTS\mbedmicro-net\udp_echo_client\TESTS-mbedmicro-net-udp_echo_client.bin" 
  -C 4 
  -c shell 
  -m K64F 
  -t 0240000029304e450038500878a3003cf131000097969900 
  -e ".\TESTS\mbedmicro-net\host_tests"
```