### PR TITLE
Add support for mbed-os/mbed/hal/targets.json

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -240,7 +240,7 @@ def main():
 
     parser.add_option('-m', '--map-target',
                     dest='map_platform_to_yt_target',
-                    help='List of custom mapping between platform name and yotta target. Comma separated list of PLATFORM:TARGET tuples')
+                    help='List of custom mapping between platform name and yotta target. Comma separated list of YOTTA_TARGET:PLATFORM tuples')
 
     parser.add_option('', '--use-tids',
                     dest='use_target_ids',

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -401,6 +401,7 @@ def run_test_thread(test_result_queue, test_queue, opts, mut, build, build_path,
         port = mut['serial_port']
         micro = mut['platform_name']
         program_cycle_s = get_platform_property(micro, "program_cycle_s")
+        forced_reset_timeout = get_platform_property(micro, "forced_reset_timeout")
         copy_method = opts.copy_method if opts.copy_method else 'shell'
         verbose = opts.verbose_test_result_only
         enum_host_tests_path = get_local_host_tests_dir(opts.enum_host_tests)
@@ -414,6 +415,7 @@ def run_test_thread(test_result_queue, test_queue, opts, mut, build, build_path,
                                          micro=micro,
                                          copy_method=copy_method,
                                          program_cycle_s=program_cycle_s,
+                                         forced_reset_timeout=forced_reset_timeout,
                                          digest_source=opts.digest_source,
                                          json_test_cfg=opts.json_test_configuration,
                                          enum_host_tests_path=enum_host_tests_path,

--- a/mbed_greentea/mbed_target_info.py
+++ b/mbed_greentea/mbed_target_info.py
@@ -33,7 +33,6 @@ from mbed_greentea.mbed_greentea_log import gt_logger
 TARGET_INFO_MAPPING = {
     "default" : {
         "program_cycle_s": 4,
-        "forced_reset_timeout": 1,
         "binary_type": ".bin",
         "copy_method": "default",
         "reset_method": "default"
@@ -346,7 +345,7 @@ def add_target_info_mapping(mbed_classic_name, map_platform_to_yt_target=None, u
 def get_mbed_clasic_target_info(mbed_classic_name, map_platform_to_yt_target=None, use_yotta_registry=False):
     """! Function resolves meta-data information about target given as mbed classic name.
     @param mbed_classic_name Mbed classic (mbed 2.0) name e.g. K64F, LPC1768 etc.
-    @param map_platform_to_yt_target User defined mapping platfrom:supported target
+    @param map_platform_to_yt_target User defined mapping platform:supported target
     @details Function first updated TARGET_INFO_MAPPING structure and later checks if mbed classic name is available in mapping structure
     @return Returns information about yotta target for specific toolchain
     """
@@ -368,8 +367,14 @@ def get_platform_property(platform, property):
     Gives platform property.
 
     :param platform:
-    :return: property value, None if propery not found
+    :return: property value, None if property not found
     """
+
+    # First load from targets.json if available
+    value_from_targets_json = get_platform_property_from_targets(platform, property)
+    if value_from_targets_json:
+        return value_from_targets_json
+
     # Check if info is available for a specific platform
     if platform in TARGET_INFO_MAPPING:
         if property in TARGET_INFO_MAPPING[platform]['properties']:
@@ -381,3 +386,28 @@ def get_platform_property(platform, property):
             return TARGET_INFO_MAPPING['default'][property]
 
     return None
+
+def get_platform_property_from_targets(platform, property):
+    """
+    Load properties from targets.json file somewhere in the project structure
+
+    :param platform:
+    :return: property value, None if property not found
+    """
+
+    result = None
+    targets_json_path = ['./mbed-os/mbed/hal/targets.json',
+                         './mbed/hal/targets.json']
+
+    for targets_path in targets_json_path:
+        try:
+            with open(targets_path, 'r') as f:
+                targets = json.load(f)
+                # Load property from targets.json
+                if platform in targets:
+                    if property in targets[platform]:
+                        result = targets[platform][property]
+        except Exception as e:
+            continue
+
+    return result

--- a/mbed_greentea/mbed_target_info.py
+++ b/mbed_greentea/mbed_target_info.py
@@ -33,6 +33,7 @@ from mbed_greentea.mbed_greentea_log import gt_logger
 TARGET_INFO_MAPPING = {
     "default" : {
         "program_cycle_s": 4,
+        "forced_reset_timeout": 1,
         "binary_type": ".bin",
         "copy_method": "default",
         "reset_method": "default"
@@ -359,8 +360,8 @@ def get_binary_type_for_platform(platform):
     :param platform:
     :return:
     """
-    return TARGET_INFO_MAPPING[platform]['properties']["binary_type"]
-
+    #return TARGET_INFO_MAPPING[platform]['properties']["binary_type"]
+    return get_platform_property(platform, 'binary_type')
 
 def get_platform_property(platform, property):
     """

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -107,6 +107,7 @@ def run_host_test(image_path,
                   verbose=False,
                   copy_method=None,
                   program_cycle_s=None,
+                  forced_reset_timeout=None,
                   digest_source=None,
                   json_test_cfg=None,
                   max_failed_properties=5,
@@ -222,6 +223,8 @@ def run_host_test(image_path,
     # Add extra parameters to host_test
     if program_cycle_s is not None:
         cmd += ["-C", str(program_cycle_s)]
+    if forced_reset_timeout:
+        cmd += ["-R", str(forced_reset_timeout)]
     if copy_method is not None:
         cmd += ["-c", copy_method]
     if micro is not None:


### PR DESCRIPTION
Changes:
* Add support for mbed-os/mbed/hal/targets.json
* Now users can additionally use flag `-R` (timeout in seconds after reset) with `mbedhtrun`.
 * Just define in `targets.json` additional field `forced_reset_timeout`.
  * Example: Define delay after reset to 3.2 seconds inside `targets.json` file:
```json
    "K64F": {
        "forced_reset_timeout": 3.2,

        "supported_form_factors": ["ARDUINO"],
        "core": "Cortex-M4F",
        "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
    },
```


