### PR TITLE
Adding default forced_reset_timeout of 1 second

### DIFF
--- a/mbed_greentea/mbed_target_info.py
+++ b/mbed_greentea/mbed_target_info.py
@@ -35,7 +35,8 @@ TARGET_INFO_MAPPING = {
         "program_cycle_s": 4,
         "binary_type": ".bin",
         "copy_method": "default",
-        "reset_method": "default"
+        "reset_method": "default",
+        "forced_reset_timeout": 1
     },
 
     "K64F" : {


### PR DESCRIPTION
This is releated to https://github.com/ARMmbed/htrun/pull/99.

This provides a default forced_reset_timeout of 1 second in the target info script. Many targets aren't ready immediately after reset, so this adds a sensible delay before sending the sync command.