### PR TITLE
Modify host_tests path crawler to remove .build/tests/TOOLCHAIN/TARGE…

### DIFF
--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -159,12 +159,13 @@ def run_host_test(image_path,
         """
         try:
             binary_path_norm = os.path.normpath(binary_path)
-            # Finding path to binary tests group
-            # From: "...\\.build\\tests\\K64F\\GCC_ARM\\TESTS\\mbedmicro-net\\udp_echo_client\\TESTS-mbedmicro-net-udp_echo_client.bin"
-            # To:   ".\\TESTS\\mbedmicro-net\\host_tests" or
-            # To:   ".\\TESTS\\host_tests"
-            host_tests_path = ['.'] + binary_path_norm.split(os.sep)[-4:-level] + ['host_tests']
-            host_tests_path = os.path.join(*host_tests_path)
+            current_path_norm = os.path.normpath(os.getcwd())
+            host_tests_path = binary_path_norm.split(os.sep)[:-level] + ['host_tests']
+
+            idx = host_tests_path.index('.build')
+            # Cut /.build/tests/TOOLCHAIN/TARGET
+            host_tests_path = host_tests_path[:idx] + host_tests_path[idx+4:]
+            host_tests_path = os.sep.join(host_tests_path)
         except Exception as e:
             gt_logger.gt_log_warn("there was a problem while looking for host_tests directory")
             gt_logger.gt_log_tab("level %d, path: %s"% (level, binary_path))


### PR DESCRIPTION
…T from image path

Example:
```python
binary_path = "c:\\Work\\mbed-os\\.build\\tests\\K64F\\GCC_ARM\\features\\FEATURE_IPV4\\TESTS\\mbedmicro-net\\nist_internet_time_service\\features-feature_ipv4-tests-mbedmicro-net-nist_internet_time_service.bin"

cwd = "c:\\Work\\mbed-os"
```
Result for level == 2:
```
c:Work\mbed-os\features\FEATURE_IPV4\TESTS\mbedmicro-net\host_tests
```
Result for level == 3:
```
c:Work\mbed-os\features\FEATURE_IPV4\TESTS\host_tests
```