### PR TITLE
Add support for ignoring tests (using -i switch) specified with -n <names>* notation.

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -110,42 +110,44 @@ def create_filtered_test_list(ctest_test_list, test_by_names, skip_test, test_sp
         @result Set with names of test names starting with 'prefix_name'
         """
         result = list()
-        print
         for test_name in test_case_name_list:
             if test_name.startswith(prefix_name):
                 result.append(test_name)
-        return result
+        return sorted(result)
 
     filtered_ctest_test_list = ctest_test_list
     test_list = None
     invalid_test_names = []
     if filtered_ctest_test_list is None:
         return {}
-    elif test_by_names:
+
+    if test_by_names:
         filtered_ctest_test_list = {}   # Subset of 'ctest_test_list'
         test_list = test_by_names.split(',')
         gt_logger.gt_log("test case filter (specified with -n option)")
 
-        for test_name in test_list:
+        for test_name in set(test_list):
             if test_name.endswith('*'):
                 # This 'star-sufix' filter allows users to filter tests with fixed prefixes
                 # Example: -n 'TESTS-mbed_drivers* will filter all test cases with name starting with 'TESTS-mbed_drivers'
                 for test_name_filtered in filter_names_by_prefix(ctest_test_list.keys(), test_name[:-1]):
+                    gt_logger.gt_log_tab("test filtered in '%s'"% gt_logger.gt_bright(test_name_filtered))
                     filtered_ctest_test_list[test_name_filtered] = ctest_test_list[test_name_filtered]
             elif test_name not in ctest_test_list:
                 invalid_test_names.append(test_name)
             else:
                 gt_logger.gt_log_tab("test filtered in '%s'"% gt_logger.gt_bright(test_name))
                 filtered_ctest_test_list[test_name] = ctest_test_list[test_name]
-    elif skip_test:
+
+    if skip_test:
         test_list = skip_test.split(',')
         gt_logger.gt_log("test case filter (specified with -i option)")
 
-        for test_name in test_list:
+        for test_name in set(test_list):
             if test_name not in ctest_test_list:
                 invalid_test_names.append(test_name)
             else:
-                gt_logger.gt_log_tab("test '%s' skipped"% gt_logger.gt_bright(test_name))
+                gt_logger.gt_log_tab("test filtered out '%s'"% gt_logger.gt_bright(test_name))
                 del filtered_ctest_test_list[test_name]
 
     if invalid_test_names:
@@ -166,6 +168,7 @@ def create_filtered_test_list(ctest_test_list, test_by_names, skip_test, test_sp
             list_binaries_for_builds(test_spec)
         else:
             list_binaries_for_targets()
+
     return filtered_ctest_test_list
 
 

--- a/test/mbed_gt_test_filtered_test_list.py
+++ b/test/mbed_gt_test_filtered_test_list.py
@@ -173,6 +173,46 @@ class GreenteaFilteredTestList(unittest.TestCase):
         self.assertEqual(len(expected), len(filtered_ctest_test_list))
         self.assertEqual(set(filtered_ctest_test_list.keys()), set(expected))
 
+    def test_prefix_filter_merge_n_and_i(self):
+        self.test_by_names='mbed-drivers-test-ticker_2,mbed-drivers-test-ticker_3,mbed-drivers-test-rtc,mbed-drivers-test-ticker'
+        self.skip_test = 'mbed-drivers-test-ticker_3'
+        filtered_ctest_test_list = mbed_greentea_cli.create_filtered_test_list(self.ctest_test_list_mbed_drivers,
+                                                                               self.test_by_names,
+                                                                               self.skip_test)
+
+        expected = ['mbed-drivers-test-ticker',
+                    'mbed-drivers-test-ticker_2',
+                    'mbed-drivers-test-rtc']
+        self.assertEqual(len(expected), len(filtered_ctest_test_list))
+        self.assertEqual(set(filtered_ctest_test_list.keys()), set(expected))
+
+    def test_prefix_filter_merge_n_and_i_repeated(self):
+        self.test_by_names='mbed-drivers-test-ticker_2,mbed-drivers-test-ticker_3,mbed-drivers-test-rtc,mbed-drivers-test-ticker'
+        self.skip_test = 'mbed-drivers-test-ticker_3,mbed-drivers-test-ticker_3'
+        filtered_ctest_test_list = mbed_greentea_cli.create_filtered_test_list(self.ctest_test_list_mbed_drivers,
+                                                                               self.test_by_names,
+                                                                               self.skip_test)
+
+        expected = ['mbed-drivers-test-ticker',
+                    'mbed-drivers-test-ticker_2',
+                    'mbed-drivers-test-rtc']
+        self.assertEqual(len(expected), len(filtered_ctest_test_list))
+        self.assertEqual(set(filtered_ctest_test_list.keys()), set(expected))
+
+    def test_prefix_filter_merge_n_and_i_missing(self):
+        self.test_by_names='mbed-drivers-test-ticker_2,mbed-drivers-test-ticker_3,mbed-drivers-test-rtc,mbed-drivers-test-ticker'
+        self.skip_test = 'mbed-drivers-test-ticker_XXX'
+        filtered_ctest_test_list = mbed_greentea_cli.create_filtered_test_list(self.ctest_test_list_mbed_drivers,
+                                                                               self.test_by_names,
+                                                                               self.skip_test)
+
+        expected = ['mbed-drivers-test-ticker',
+                    'mbed-drivers-test-ticker_2',
+                    'mbed-drivers-test-ticker_3',
+                    'mbed-drivers-test-rtc']
+        self.assertEqual(len(expected), len(filtered_ctest_test_list))
+        self.assertEqual(set(filtered_ctest_test_list.keys()), set(expected))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Changes:
* Now you can specify `-n <name>*` and `-i <names>` together
* Added unit tests for this command mix

```
$ mbedgt -VS -n mbed-drivers-test-t* -i mbed-drivers-test-ticker_3
```

```
...
mbedgt: test case filter (specified with -n option)
        test filtered in 'mbed-drivers-test-ticker'
        test filtered in 'mbed-drivers-test-ticker_2'
        test filtered in 'mbed-drivers-test-ticker_3'
        test filtered in 'mbed-drivers-test-timeout'
mbedgt: test case filter (specified with -i option)
        test filtered out 'mbed-drivers-test-ticker_3'
...
```