### PR TITLE
Replace available devices and MUTs in use for test prints with pretty table

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -32,7 +32,6 @@ from mbed_greentea.mbed_test_api import get_test_build_properties
 from mbed_greentea.mbed_test_api import get_test_spec
 from mbed_greentea.mbed_test_api import run_host_test
 from mbed_greentea.mbed_test_api import log_mbed_devices_in_table
-from mbed_greentea.mbed_test_api import log_mbed_devices_properties
 from mbed_greentea.mbed_test_api import TEST_RESULTS
 from mbed_greentea.mbed_test_api import TEST_RESULT_OK, TEST_RESULT_FAIL
 from mbed_greentea.mbed_report_api import exporter_text

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -31,6 +31,7 @@ from threading import Thread
 from mbed_greentea.mbed_test_api import get_test_build_properties
 from mbed_greentea.mbed_test_api import get_test_spec
 from mbed_greentea.mbed_test_api import run_host_test
+from mbed_greentea.mbed_test_api import log_mbed_devices_in_table
 from mbed_greentea.mbed_test_api import log_mbed_devices_properties
 from mbed_greentea.mbed_test_api import TEST_RESULTS
 from mbed_greentea.mbed_test_api import TEST_RESULT_OK, TEST_RESULT_FAIL
@@ -670,6 +671,10 @@ def main_cli(opts, args, gt_instance_uuid=None):
 
     if mbeds_list:
         ready_mbed_devices, not_ready_mbed_devices = filter_ready_devices(mbeds_list)
+        if ready_mbed_devices:
+            # devices in form of a pretty formatted table
+            for line in log_mbed_devices_in_table(ready_mbed_devices).splitlines():
+                gt_logger.gt_log_tab(line.strip())
     else:
         gt_logger.gt_log_err("no compatible devices detected")
         return (RET_NO_DEVICES)
@@ -715,8 +720,10 @@ def main_cli(opts, args, gt_instance_uuid=None):
     filter_test_builds = opts.list_of_targets.split(',') if opts.list_of_targets else None
     for test_build in test_spec.get_test_builds(filter_test_builds):
         platform_name = test_build.get_platform()
-        gt_logger.gt_log("processing target '%s' toolchain '%s' compatible platforms..." %
-                         (gt_logger.gt_bright(platform_name), gt_logger.gt_bright(test_build.get_toolchain())))
+        gt_logger.gt_log("processing target '%s' toolchain '%s' compatible platforms... (note: switch set to --parallel %d)" %
+                         (gt_logger.gt_bright(platform_name),
+                          gt_logger.gt_bright(test_build.get_toolchain()),
+                          int(opts.parallel_test_exec)))
 
         baudrate = test_build.get_baudrate()
 
@@ -736,12 +743,15 @@ def main_cli(opts, args, gt_instance_uuid=None):
                 mut = mbed_dev
                 muts_to_test.append(mbed_dev)
                 # Log on screen mbed device properties
-                gt_logger.gt_log("using platform '%s' for test:"% gt_logger.gt_bright(platform_name))
-                log_mbed_devices_properties(mbed_dev, verbose=opts.verbose)
+                #gt_logger.gt_log("using platform '%s' for test:"% gt_logger.gt_bright(platform_name))
                 if number_of_parallel_instances < parallel_test_exec:
                     number_of_parallel_instances += 1
                 else:
                     break
+
+        # devices in form of a pretty formatted table
+        for line in log_mbed_devices_in_table(muts_to_test).splitlines():
+            gt_logger.gt_log_tab(line.strip())
 
         # Configuration print mode:
         if opts.verbose_test_configuration_only:

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -741,8 +741,6 @@ def main_cli(opts, args, gt_instance_uuid=None):
                     mbed_dev['serial_port'] = "%s:%d" % (mbed_dev['serial_port'], baudrate)
                 mut = mbed_dev
                 muts_to_test.append(mbed_dev)
-                # Log on screen mbed device properties
-                #gt_logger.gt_log("using platform '%s' for test:"% gt_logger.gt_bright(platform_name))
                 if number_of_parallel_instances < parallel_test_exec:
                     number_of_parallel_instances += 1
                 else:

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -427,6 +427,26 @@ def log_mbed_devices_properties(mbed_dev, verbose=False):
     for k in dev_prop:
         gt_logger.gt_log_tab("%s = '%s'"% (k, mbed_dev[k]))
 
+def log_mbed_devices_in_table(muts, cols = ['platform_name', 'platform_name_unique', 'serial_port', 'mount_point', 'target_id']):
+    """! Print table of muts using prettytable
+    @param muts List of MUTs to print in table
+    @param cols Columns used to for a table, required for each mut
+    @return string with formatted prettytable
+    """
+    from prettytable import PrettyTable
+    pt = PrettyTable(cols)
+    for col in cols:
+        pt.align[col] = "l"
+    pt.padding_width = 1 # One space between column edges and contents (default)
+    row = []
+    for mut in muts:
+        for col in cols:
+            cell_val = mut[col] if col in mut else 'not detected'
+            row.append(cell_val)
+        pt.add_row(row)
+        row = []
+    return pt.get_string()
+
 def get_test_spec(opts):
     """! Closure encapsulating how we get test specification and load it from file of from yotta module
     @return Returns tuple of (test specification, ret code). Test specification == None if test spec load was not successful

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -417,16 +417,6 @@ def get_testcase_result(output):
 
     return result_test_cases
 
-def log_mbed_devices_properties(mbed_dev, verbose=False):
-    """! Separate function to log mbed device properties on the screen
-    """
-    # Short subset of MUT properties in verbose mode
-    dev_prop_short = ['target_id', 'mount_point', 'serial_port', 'daplink_version']
-
-    dev_prop = [x for x in mbed_dev.keys() if x in dev_prop_short] if not verbose else mbed_dev.keys()
-    for k in dev_prop:
-        gt_logger.gt_log_tab("%s = '%s'"% (k, mbed_dev[k]))
-
 def log_mbed_devices_in_table(muts, cols = ['platform_name', 'platform_name_unique', 'serial_port', 'mount_point', 'target_id']):
     """! Print table of muts using prettytable
     @param muts List of MUTs to print in table


### PR DESCRIPTION
Changes:
* Replace verbose prints for available devices and devices under tests with simple tables (like mbed-ls).
* It makes Greentea log shorter and easier to read.

### Example
```
mbedgt: detecting connected mbed-enabled devices...
mbedgt: detected 4 devices
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
        | platform_name | platform_name_unique | serial_port | mount_point | target_id                                        |
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
        | NUCLEO_F401RE | NUCLEO_F401RE[0]     | COM163      | E:          | 07200200076165023804F31F                         |
        | K64F          | K64F[0]              | COM219      | F:          | 0240000033514e450019500585d40008e981000097969900 |
        | K64F          | K64F[1]              | COM229      | G:          | 0240000033514e450040500585d4000be981000097969900 |
        | K64F          | K64F[2]              | COM244      | H:          | 0240000028634e45003350066917001f5f21000097969900 |
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
mbedgt: processing target 'K64F' toolchain 'frdm-k64f-gcc' compatible platforms... (note: switch set to --parallel 1)
        +---------------+----------------------+---------------+-------------+--------------------------------------------------+
        | platform_name | platform_name_unique | serial_port   | mount_point | target_id                                        |
        +---------------+----------------------+---------------+-------------+--------------------------------------------------+
        | K64F          | K64F[0]              | COM219:115200 | F:          | 0240000033514e450019500585d40008e981000097969900 |
        +---------------+----------------------+---------------+-------------+--------------------------------------------------+
```