### PR TITLE
Add recursive search for test_spec.json in mbed-os and mbed-os app dir level

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -601,13 +601,6 @@ def main_cli(opts, args, gt_instance_uuid=None):
             else:
                 # Adding MUT to DETECTED CORRECTLY list
                 ready_mbed_devices.append(mut)
-                gt_logger.gt_log_tab("detected '%s' -> '%s', console at '%s', mounted at '%s', target id '%s'"% (
-                    gt_logger.gt_bright(mut['platform_name']),
-                    gt_logger.gt_bright(mut['platform_name_unique']),
-                    gt_logger.gt_bright(mut['serial_port']),
-                    gt_logger.gt_bright(mut['mount_point']),
-                    gt_logger.gt_bright(mut['target_id'])
-                ))
         return (ready_mbed_devices, not_ready_mbed_devices)
 
     if not MBED_LMTOOLS:

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -20,6 +20,7 @@ Author: Przemyslaw Wirkus <Przemyslaw.wirkus@arm.com>
 import re
 import os
 import sys
+import json
 from time import time
 from subprocess import Popen, PIPE, STDOUT
 
@@ -445,20 +446,66 @@ def get_test_spec(opts):
 
     # Check if test_spec.json file exist, if so we will pick it up as default file and load it
     test_spec_file_name = opts.test_spec
+    test_spec_file_name_list = []
 
     # Note: test_spec.json will have higher priority than module.json file
     #       so if we are inside directory with module.json and test_spec.json we will use test spec file
     #       instead of using yotta's module.json file
 
+    def get_all_test_specs_from_build_dir(path_to_scan):
+        """! Searches for all test_spec.json files
+        @param path_to_scan Directory path used to recursively search for test_spec.json
+        @result List of locations of test_spec.json
+        """
+        return [os.path.join(dp, f) for dp, dn, filenames in os.walk(path_to_scan) for f in filenames if f == 'test_spec.json']
+
+    def merge_multiple_test_specifications_from_file_list(test_spec_file_name_list):
+        """! For each file in test_spec_file_name_list merge all test specifications into one
+        @param test_spec_file_name_list List of paths to different test specifications
+        @return TestSpec object with all test specification data inside
+        """
+        merged_test_spec = {}
+        for test_spec_file in test_spec_file_name_list:
+            gt_logger.gt_log_tab("using '%s'"% test_spec_file)
+            try:
+                with open(test_spec_file, 'r') as f:
+                    test_spec_data = json.load(f)
+                    merged_test_spec.update(test_spec_data)
+            except Exception as e:
+                gt_logger.gt_log_err("Unexpected error while processing '%s' test specification file"% test_spec_file)
+                gt_logger.gt_log_tab(str(e))
+                merged_test_spec = {}
+        test_spec = TestSpec()
+        test_spec.parse(merged_test_spec)
+        return test_spec
+
+    # Test specification look-up
     if opts.test_spec:
+        # Loading test specification from command line specified file
         gt_logger.gt_log("test specification file '%s' (specified with --test-spec option)"% opts.test_spec)
     elif os.path.exists('test_spec.json'):
+        # Test specification file exists in current directory
+        gt_logger.gt_log("using 'test_spec.json' from current directory!")
         test_spec_file_name = 'test_spec.json'
+    elif os.path.exists('.build'):
+        # Checking .build directory for test specifications
+        test_spec_file_name_list = get_all_test_specs_from_build_dir('.build')
+    elif os.path.exists(os.path.join('mbed-os', '.build')):
+        # Checking mbed-os/.build directory for test specifications
+        test_spec_file_name_list = get_all_test_specs_from_build_dir(os.path.join(['mbed-os', '.build']))
 
+    # Actual load and processing of test specification from sources
     if test_spec_file_name:
-        # Test spec from command line (--test-spec) or default test_spec.json will be used
+        # Test specification from command line (--test-spec) or default test_spec.json will be used
         gt_logger.gt_log("using '%s' from current directory!"% test_spec_file_name)
         test_spec = TestSpec(test_spec_file_name)
+        if opts.list_binaries:
+            list_binaries_for_builds(test_spec)
+            return None, 0
+    elif test_spec_file_name_list:
+        # Merge multiple test specs into one and keep calm
+        gt_logger.gt_log("using multiple test specifications from current directory!")
+        test_spec = merge_multiple_test_specifications_from_file_list(test_spec_file_name_list)
         if opts.list_binaries:
             list_binaries_for_builds(test_spec)
             return None, 0

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -464,17 +464,31 @@ def get_test_spec(opts):
         @param test_spec_file_name_list List of paths to different test specifications
         @return TestSpec object with all test specification data inside
         """
+
+        def copy_builds_between_test_specs(source, destination):
+            """! Copies build key-value pairs between two test_spec dicts
+                @param source Source dictionary
+                @param destination Dictionary with will be applied with 'builds' key-values
+                @return Dictionary with merged source
+            """
+            result = destination.copy()
+            if 'builds' in source and 'builds' in destination:
+                for k in source['builds']:
+                    result['builds'][k] = source['builds'][k]
+            return result
+
         merged_test_spec = {}
         for test_spec_file in test_spec_file_name_list:
             gt_logger.gt_log_tab("using '%s'"% test_spec_file)
             try:
                 with open(test_spec_file, 'r') as f:
                     test_spec_data = json.load(f)
-                    merged_test_spec.update(test_spec_data)
+                    merged_test_spec = copy_builds_between_test_specs(merged_test_spec, test_spec_data)
             except Exception as e:
                 gt_logger.gt_log_err("Unexpected error while processing '%s' test specification file"% test_spec_file)
                 gt_logger.gt_log_tab(str(e))
                 merged_test_spec = {}
+
         test_spec = TestSpec()
         test_spec.parse(merged_test_spec)
         return test_spec


### PR DESCRIPTION
## Description

When using `mbedgt -l` without `test_spec.json` in current directory we were unable to list test cases with standard list command line switch. With this improvement we can list test specification content on screen. 

This PR changes the way Greentea looks for yotta module, test specification file. Order is:
* Test specification defined with `--test-spec`
* Local directory `test_spec.json`
* Recursive search and merge of test specifications from `./.build` directory
* Recursive search and merge of test specifications from `./mbed-os/.build` directory
* Local directory `module.json`

## Before this change
```
[master] C:\Work\mbed-os> mbedgt -l
```
```
mbedgt: greentea should be run inside a Yotta module or --test-spec switch should be used.
mbedgt: exited with code -1
```

## After change mbed-drivers directory
```
[master] C:\Work\mbed-drivers> mbedgt -l
```
```
mbedgt: using 'module.json' from current directory!
mbedgt: available tests for target 'frdm-k64f-armcc', location 'c:\Work\mbed-drivers\build\build\frdm-k64f-armcc'
        test 'mbed-drivers-test-c_strings'
        test 'mbed-drivers-test-dev_null'
        test 'mbed-drivers-test-echo'
        test 'mbed-drivers-test-generic_tests'
        test 'mbed-drivers-test-rtc'
        test 'mbed-drivers-test-stl_features'
        test 'mbed-drivers-test-ticker'
        test 'mbed-drivers-test-ticker_2'
        test 'mbed-drivers-test-ticker_3'
        test 'mbed-drivers-test-timeout'
        test 'mbed-drivers-test-wait_us'
mbedgt: available tests for target 'frdm-k64f-gcc', location 'c:\Work\mbed-drivers\build\build\frdm-k64f-gcc'
        test 'mbed-drivers-test-c_strings'
        test 'mbed-drivers-test-dev_null'
        test 'mbed-drivers-test-echo'
        test 'mbed-drivers-test-generic_tests'
        test 'mbed-drivers-test-rtc'
        test 'mbed-drivers-test-stl_features'
        test 'mbed-drivers-test-ticker'
        test 'mbed-drivers-test-ticker_2'
        test 'mbed-drivers-test-ticker_3'
        test 'mbed-drivers-test-timeout'
        test 'mbed-drivers-test-wait_us'
        test 'mbed-drivers-test-xxx'
```

## After change mbed-os directory
```
[master] C:\Work\mbed-os> mbedgt -l
```
```
mbedgt: using multiple test specifications from current directory!
        using '.build\tests\K64F\GCC_ARM\test_spec.json'
mbedgt: available tests for built 'K64F-GCC_ARM', location 'c:\Work\mbed-os\.build/tests\K64F\GCC_ARM'
        test 'features-feature_ipv4-tests-mbedmicro-net-nist_internet_time_service'
        test 'features-feature_ipv4-tests-mbedmicro-net-tcp_client_echo'
        test 'features-feature_ipv4-tests-mbedmicro-net-tcp_client_hello_world'
        test 'features-feature_ipv4-tests-mbedmicro-net-udp_echo_client'
        test 'features-storage-tests-cfstore-add_del'
        test 'features-storage-tests-cfstore-close'
        test 'features-storage-tests-cfstore-create'
        test 'features-storage-tests-cfstore-example1'
        test 'features-storage-tests-cfstore-example2'
        test 'features-storage-tests-cfstore-example3'
        test 'features-storage-tests-cfstore-example4'
        test 'features-storage-tests-cfstore-example5'
        test 'features-storage-tests-cfstore-find'
        test 'features-storage-tests-cfstore-find2'
        test 'features-storage-tests-cfstore-flash'
        test 'features-storage-tests-cfstore-flush'
        test 'features-storage-tests-cfstore-flush2'
        test 'features-storage-tests-cfstore-init'
        test 'features-storage-tests-cfstore-misc'
        test 'features-storage-tests-cfstore-open'
        test 'features-storage-tests-cfstore-read'
        test 'features-storage-tests-cfstore-write'
        test 'features-storage-tests-flash_journal-basicapi'
        test 'frameworks-utest-tests-unit_tests-basic_test'
        test 'frameworks-utest-tests-unit_tests-case_async_validate'
        test 'frameworks-utest-tests-unit_tests-case_control_async'
        test 'frameworks-utest-tests-unit_tests-case_control_repeat'
        test 'frameworks-utest-tests-unit_tests-case_selection'
        test 'frameworks-utest-tests-unit_tests-case_setup_failure'
        test 'frameworks-utest-tests-unit_tests-case_teardown_failure'
        test 'frameworks-utest-tests-unit_tests-control_type'
        test 'frameworks-utest-tests-unit_tests-minimal_async_scheduler'
        test 'frameworks-utest-tests-unit_tests-minimal_scheduler'
        test 'frameworks-utest-tests-unit_tests-test_assertion_failure_test_setup'
        test 'frameworks-utest-tests-unit_tests-test_setup_case_selection_failure'
        test 'frameworks-utest-tests-unit_tests-test_setup_failure'
        test 'tests-integration-basic'
        test 'tests-integration-threaded_blinky'
        test 'tests-mbed_drivers-c_strings'
        test 'tests-mbed_drivers-callback'
        test 'tests-mbed_drivers-dev_null'
        test 'tests-mbed_drivers-echo'
        test 'tests-mbed_drivers-generic_tests'
        test 'tests-mbed_drivers-rtc'
        test 'tests-mbed_drivers-stl_features'
        test 'tests-mbed_drivers-ticker'
        test 'tests-mbed_drivers-ticker_2'
        test 'tests-mbed_drivers-ticker_3'
        test 'tests-mbed_drivers-timeout'
        test 'tests-mbed_drivers-wait_us'
        test 'tests-mbedmicro-mbed-attributes'
        test 'tests-mbedmicro-mbed-call_before_main'
        test 'tests-mbedmicro-mbed-cpp'
        test 'tests-mbedmicro-mbed-div'
        test 'tests-mbedmicro-mbed-heap_and_stack'
        test 'tests-mbedmicro-rtos-mbed-basic'
        test 'tests-mbedmicro-rtos-mbed-isr'
        test 'tests-mbedmicro-rtos-mbed-mail'
        test 'tests-mbedmicro-rtos-mbed-mutex'
        test 'tests-mbedmicro-rtos-mbed-queue'
        test 'tests-mbedmicro-rtos-mbed-semaphore'
        test 'tests-mbedmicro-rtos-mbed-signals'
        test 'tests-mbedmicro-rtos-mbed-threads'
        test 'tests-mbedmicro-rtos-mbed-timer'
        test 'tests-storage_abstraction-basicapi'
```