### PR TITLE
Add support for SKIPPED test cases

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -601,13 +601,6 @@ def main_cli(opts, args, gt_instance_uuid=None):
             else:
                 # Adding MUT to DETECTED CORRECTLY list
                 ready_mbed_devices.append(mut)
-                gt_logger.gt_log_tab("detected '%s' -> '%s', console at '%s', mounted at '%s', target id '%s'"% (
-                    gt_logger.gt_bright(mut['platform_name']),
-                    gt_logger.gt_bright(mut['platform_name_unique']),
-                    gt_logger.gt_bright(mut['serial_port']),
-                    gt_logger.gt_bright(mut['mount_point']),
-                    gt_logger.gt_bright(mut['target_id'])
-                ))
         return (ready_mbed_devices, not_ready_mbed_devices)
 
     if not MBED_LMTOOLS:

--- a/mbed_greentea/mbed_report_api.py
+++ b/mbed_greentea/mbed_report_api.py
@@ -33,42 +33,6 @@ def export_to_file(file_name, payload):
     return result
 
 
-def exporter_junit(test_result_ext, test_suite_properties=None):
-    """! Export test results in JUnit XML compliant format
-    @details This function will import junit_xml library to perform report conversion
-    @return String containing Junit XML formatted test result output
-    """
-    from junit_xml import TestSuite, TestCase
-
-    test_suites = []
-    test_cases = []
-
-    targets = sorted(test_result_ext.keys())
-    for target in targets:
-        test_cases = []
-        tests = sorted(test_result_ext[target].keys())
-        for test in tests:
-            test_results = test_result_ext[target][test]
-            classname = 'test.%s.%s' % (target, test)
-            elapsed_sec = test_results['elapsed_time']
-            _stdout = test_results['single_test_output']
-            _stderr = ''
-            # Test case
-            tc = TestCase(test, classname, elapsed_sec, _stdout, _stderr)
-            # Test case extra failure / error info
-            if test_results['single_test_result'] == 'FAIL':
-                message = test_results['single_test_result']
-                tc.add_failure_info(message, _stdout)
-            elif test_results['single_test_result'] != 'OK':
-                message = test_results['single_test_result']
-                tc.add_error_info(message, _stdout)
-
-            test_cases.append(tc)
-        ts = TestSuite("test.suite.%s" % target, test_cases)
-        test_suites.append(ts)
-    return TestSuite.to_xml_string(test_suites)
-
-
 def exporter_json(test_result_ext, test_suite_properties=None):
     """! Exports test results to indented JSON format
     @details This is a machine friendly format
@@ -228,9 +192,11 @@ def exporter_testcase_junit(test_result_ext, test_suite_properties=None):
 
                 tc_class = target_name + '.' + test_suite_name
                 tc = TestCase(tc_name, tc_class, duration, tc_stdout, tc_stderr)
-                
+
                 if result_text == 'FAIL':
                     tc.add_failure_info(result_text, tc_stdout)
+                elif result_text == 'SKIPPED':
+                    tc.add_skipped_info(result_text, tc_stdout)
                 elif result_text != 'OK':
                     tc.add_error_info(result_text, tc_stdout)
 

--- a/test/mbed_gt_test_api.py
+++ b/test/mbed_gt_test_api.py
@@ -185,6 +185,46 @@ class GreenteaTestAPI(unittest.TestCase):
 [1459246276.98][HTST][INF] {{result;failure}}
 """
 
+        self.OUTOUT_CSTRING_TEST_CASE_COUNT_AND_NAME = """
+[1467197417.13][SERI][TXD] {{__sync;3018cb93-f11c-417e-bf61-240c338dfec9}}
+[1467197417.27][CONN][RXD] {{__sync;3018cb93-f11c-417e-bf61-240c338dfec9}}
+[1467197417.27][CONN][INF] found SYNC in stream: {{__sync;3018cb93-f11c-417e-bf61-240c338dfec9}} it is #0 sent, queued...
+[1467197417.27][HTST][INF] sync KV found, uuid=3018cb93-f11c-417e-bf61-240c338dfec9, timestamp=1467197417.272000
+[1467197417.29][CONN][RXD] {{__version;1.1.0}}
+[1467197417.29][CONN][INF] found KV pair in stream: {{__version;1.1.0}}, queued...
+[1467197417.29][HTST][INF] DUT greentea-client version: 1.1.0
+[1467197417.31][CONN][RXD] {{__timeout;5}}
+[1467197417.31][CONN][INF] found KV pair in stream: {{__timeout;5}}, queued...
+[1467197417.31][HTST][INF] setting timeout to: 5 sec
+[1467197417.34][CONN][RXD] {{__host_test_name;default_auto}}
+[1467197417.34][CONN][INF] found KV pair in stream: {{__host_test_name;default_auto}}, queued...
+[1467197417.34][HTST][INF] host test class: '<class 'mbed_host_tests.host_tests.default_auto.DefaultAuto'>'
+[1467197417.34][HTST][INF] host test setup() call...
+[1467197417.34][HTST][INF] CALLBACKs updated
+[1467197417.34][HTST][INF] host test detected: default_auto
+[1467197417.36][CONN][RXD] {{__testcase_count;2}}
+[1467197417.36][CONN][INF] found KV pair in stream: {{__testcase_count;2}}, queued...
+[1467197417.39][CONN][RXD] >>> Running 2 test cases...
+[1467197417.43][CONN][RXD] {{__testcase_name;C strings: strtok}}
+[1467197417.43][CONN][INF] found KV pair in stream: {{__testcase_name;C strings: strtok}}, queued...
+[1467197417.47][CONN][RXD] {{__testcase_name;C strings: strpbrk}}
+[1467197417.47][CONN][INF] found KV pair in stream: {{__testcase_name;C strings: strpbrk}}, queued...
+[1467197417.52][CONN][RXD] >>> Running case #1: 'C strings: strtok'...
+[1467197417.56][CONN][RXD] {{__testcase_start;C strings: strtok}}
+[1467197417.56][CONN][INF] found KV pair in stream: {{__testcase_start;C strings: strtok}}, queued...
+[1467197422.31][HTST][INF] test suite run finished after 5.00 sec...
+[1467197422.31][CONN][INF] received special even '__host_test_finished' value='True', finishing
+[1467197422.33][HTST][INF] CONN exited with code: 0
+[1467197422.33][HTST][INF] No events in queue
+[1467197422.33][HTST][INF] stopped consuming events
+[1467197422.33][HTST][INF] host test result(): None
+[1467197422.33][HTST][WRN] missing __exit event from DUT
+[1467197422.33][HTST][ERR] missing __exit event from DUT and no result from host test, timeout...
+[1467197422.33][HTST][INF] calling blocking teardown()
+[1467197422.33][HTST][INF] teardown() finished
+[1467197422.33][HTST][INF] {{result;timeout}}
+"""
+
     def tearDown(self):
         pass
 
@@ -219,6 +259,13 @@ class GreenteaTestAPI(unittest.TestCase):
         self.assertIn("[1459246276.25][CONN][INF] found KV pair in stream: {{__testcase_finish;C strings: %f %f float formatting;0;1}}, queued...", r)
         self.assertIn("[1459246276.25][CONN][RXD] {{__testcase_finish;C strings: %f %f float formatting;0;1}}", r)
         self.assertIn("[1459246276.34][CONN][RXD] >>> 'C strings: %f %f float formatting': 0 passed, 1 failed with reason 'Test Cases Failed'", r)
+
+    def get_testcase_count_and_names(self):
+        tc_count, tc_names = mbed_test_api.get_testcase_count_and_names(self.OUTOUT_CSTRING_TEST_CASE_COUNT_AND_NAME)
+
+        self.assertEqual(tc_count, 2)
+        self.assertIn('C strings: strtok', tc_names)
+        self.assertIn('C strings: strpbrk', tc_names)
 
     def test_get_test_result_return_val(self):
 

--- a/test/mbed_gt_test_api.py
+++ b/test/mbed_gt_test_api.py
@@ -225,6 +225,106 @@ class GreenteaTestAPI(unittest.TestCase):
 [1467197422.33][HTST][INF] {{result;timeout}}
 """
 
+        self.OUTOUT_GENERIC_TESTS_TESCASE_NAME_AND_COUNT = """
+[1467205002.74][HTST][INF] host test executor ver. 0.2.19
+[1467205002.74][HTST][INF] copy image onto target...
+        1 file(s) copied.
+Plugin info: HostTestPluginCopyMethod_Shell::CopyMethod: Waiting up to 60 sec for '0240000033514e450019500585d40008e981000097969900' mount point (current is 'F:')...
+[1467205011.16][HTST][INF] starting host test process...
+[1467205011.74][CONN][INF] starting serial connection process...
+[1467205011.74][CONN][INF] notify event queue about extra 60 sec timeout for serial port pooling
+[1467205011.74][CONN][INF] initializing serial port listener...
+[1467205011.74][HTST][INF] setting timeout to: 60 sec
+[1467205011.74][SERI][INF] serial(port=COM219, baudrate=9600, timeout=0)
+Plugin info: HostTestPluginBase::BasePlugin: Waiting up to 60 sec for '0240000033514e450019500585d40008e981000097969900' serial port (current is 'COM219')...
+[1467205011.83][SERI][INF] reset device using 'default' plugin...
+[1467205012.08][SERI][INF] waiting 1.00 sec after reset
+[1467205013.08][SERI][INF] wait for it...
+[1467205013.08][SERI][TXD] mbedmbedmbedmbedmbedmbedmbedmbedmbedmbed
+[1467205013.08][CONN][INF] sending up to 2 __sync packets (specified with --sync=2)
+[1467205013.08][CONN][INF] sending preamble 'f82e0251-bb3e-4434-bc93-b780b5d0e82a'
+[1467205013.08][SERI][TXD] {{__sync;f82e0251-bb3e-4434-bc93-b780b5d0e82a}}
+[1467205013.22][CONN][RXD] {{__sync;f82e0251-bb3e-4434-bc93-b780b5d0e82a}}
+[1467205013.22][CONN][INF] found SYNC in stream: {{__sync;f82e0251-bb3e-4434-bc93-b780b5d0e82a}} it is #0 sent, queued...
+[1467205013.22][HTST][INF] sync KV found, uuid=f82e0251-bb3e-4434-bc93-b780b5d0e82a, timestamp=1467205013.219000
+[1467205013.24][CONN][RXD] {{__version;1.1.0}}
+[1467205013.24][CONN][INF] found KV pair in stream: {{__version;1.1.0}}, queued...
+[1467205013.24][HTST][INF] DUT greentea-client version: 1.1.0
+[1467205013.25][CONN][RXD] {{__timeout;20}}
+[1467205013.26][CONN][INF] found KV pair in stream: {{__timeout;20}}, queued...
+[1467205013.26][HTST][INF] setting timeout to: 20 sec
+[1467205013.29][CONN][RXD] {{__host_test_name;default_auto}}
+[1467205013.29][CONN][INF] found KV pair in stream: {{__host_test_name;default_auto}}, queued...
+[1467205013.29][HTST][INF] host test class: '<class 'mbed_host_tests.host_tests.default_auto.DefaultAuto'>'
+[1467205013.29][HTST][INF] host test setup() call...
+[1467205013.29][HTST][INF] CALLBACKs updated
+[1467205013.29][HTST][INF] host test detected: default_auto
+[1467205013.31][CONN][RXD] {{__testcase_count;4}}
+[1467205013.31][CONN][INF] found KV pair in stream: {{__testcase_count;4}}, queued...
+[1467205013.34][CONN][RXD] >>> Running 4 test cases...
+[1467205013.37][CONN][RXD] {{__testcase_name;Basic}}
+[1467205013.37][CONN][INF] found KV pair in stream: {{__testcase_name;Basic}}, queued...
+[1467205013.40][CONN][RXD] {{__testcase_name;Blinky}}
+[1467205013.40][CONN][INF] found KV pair in stream: {{__testcase_name;Blinky}}, queued...
+[1467205013.43][CONN][RXD] {{__testcase_name;C++ stack}}
+[1467205013.43][CONN][INF] found KV pair in stream: {{__testcase_name;C++ stack}}, queued...
+[1467205013.46][CONN][RXD] {{__testcase_name;C++ heap}}
+[1467205013.46][CONN][INF] found KV pair in stream: {{__testcase_name;C++ heap}}, queued...
+[1467205013.49][CONN][RXD] >>> Running case #1: 'Basic'...
+[1467205013.52][CONN][RXD] {{__testcase_start;Basic}}
+[1467205013.52][CONN][INF] found KV pair in stream: {{__testcase_start;Basic}}, queued...
+[1467205013.56][CONN][RXD] {{__testcase_finish;Basic;1;0}}
+[1467205013.56][CONN][INF] found KV pair in stream: {{__testcase_finish;Basic;1;0}}, queued...
+[1467205013.59][CONN][RXD] >>> 'Basic': 1 passed, 0 failed
+[1467205013.62][CONN][RXD] >>> Running case #2: 'Blinky'...
+[1467205013.65][CONN][RXD] {{__testcase_start;Blinky}}
+[1467205013.65][CONN][INF] found KV pair in stream: {{__testcase_start;Blinky}}, queued...
+[1467205013.69][CONN][RXD] {{__testcase_finish;Blinky;1;0}}
+[1467205013.69][CONN][INF] found KV pair in stream: {{__testcase_finish;Blinky;1;0}}, queued...
+[1467205013.72][CONN][RXD] >>> 'Blinky': 1 passed, 0 failed
+[1467205013.75][CONN][RXD] >>> Running case #3: 'C++ stack'...
+[1467205013.78][CONN][RXD] {{__testcase_start;C++ stack}}
+[1467205013.78][CONN][INF] found KV pair in stream: {{__testcase_start;C++ stack}}, queued...
+[1467205013.79][CONN][RXD] Static::init
+[1467205013.81][CONN][RXD] Static::stack_test
+[1467205013.82][CONN][RXD] Stack::init
+[1467205013.85][CONN][RXD] Stack::hello
+[1467205013.87][CONN][RXD] Stack::destroy
+[1467205013.89][CONN][RXD] Static::check_init: OK
+[1467205013.91][CONN][RXD] Static::destroy
+[1467205013.94][CONN][RXD] {{__testcase_finish;C++ stack;1;0}}
+[1467205013.95][CONN][INF] found KV pair in stream: {{__testcase_finish;C++ stack;1;0}}, queued...
+[1467205013.98][CONN][RXD] >>> 'C++ stack': 1 passed, 0 failed
+[1467205014.02][CONN][RXD] >>> Running case #4: 'C++ heap'...
+[1467205014.05][CONN][RXD] {{__testcase_start;C++ heap}}
+[1467205014.05][CONN][INF] found KV pair in stream: {{__testcase_start;C++ heap}}, queued...
+[1467205014.06][CONN][RXD] Heap::init
+[1467205014.07][CONN][RXD] Heap::hello
+[1467205014.10][CONN][RXD] Heap::check_init: OK
+[1467205014.11][CONN][RXD] Heap::destroy
+[1467205014.15][CONN][RXD] {{__testcase_finish;C++ heap;1;0}}
+[1467205014.15][CONN][INF] found KV pair in stream: {{__testcase_finish;C++ heap;1;0}}, queued...
+[1467205014.18][CONN][RXD] >>> 'C++ heap': 1 passed, 0 failed
+[1467205014.22][CONN][RXD] >>> Test cases: 4 passed, 0 failed
+[1467205014.25][CONN][RXD] {{__testcase_summary;4;0}}
+[1467205014.25][CONN][INF] found KV pair in stream: {{__testcase_summary;4;0}}, queued...
+[1467205014.27][CONN][RXD] {{end;success}}
+[1467205014.27][CONN][INF] found KV pair in stream: {{end;success}}, queued...
+[1467205014.28][CONN][RXD] {{__exit;0}}
+[1467205014.28][CONN][INF] found KV pair in stream: {{__exit;0}}, queued...
+[1467205014.28][HTST][INF] __exit(0)
+[1467205014.28][HTST][INF] test suite run finished after 1.02 sec...
+[1467205014.28][CONN][INF] received special even '__host_test_finished' value='True', finishing
+[1467205014.31][HTST][INF] CONN exited with code: 0
+[1467205014.31][HTST][INF] Some events in queue
+[1467205014.31][HTST][INF] __notify_complete(True)
+[1467205014.31][HTST][INF] stopped consuming events
+[1467205014.31][HTST][INF] host test result() call skipped, received: True
+[1467205014.31][HTST][INF] calling blocking teardown()
+[1467205014.31][HTST][INF] teardown() finished
+[1467205014.31][HTST][INF] {{result;success}}
+"""
+
     def tearDown(self):
         pass
 
@@ -337,7 +437,7 @@ class GreenteaTestAPI(unittest.TestCase):
 
         for test_case in test_case_names:
             tc = r[test_case]
-            # If datastructure is correct
+            # If data structure is correct
             self.assertIn('utest_log', tc)
             self.assertIn('time_start', tc)
             self.assertIn('time_end', tc)
@@ -355,6 +455,25 @@ class GreenteaTestAPI(unittest.TestCase):
         self.assertEqual(tc['passed'], 0)
         self.assertEqual(tc['failed'], 1)
         self.assertEqual(tc['result_text'], 'FAIL')
+
+    def test_get_testcase_result_tescase_name_and_count(self):
+        r = mbed_test_api.get_testcase_result(self.OUTOUT_GENERIC_TESTS_TESCASE_NAME_AND_COUNT)
+        self.assertEqual(len(r), 4)
+
+        self.assertIn('Basic', r)
+        self.assertIn('Blinky', r)
+        self.assertIn('C++ heap', r)
+        self.assertIn('C++ stack', r)
+
+    def test_get_testcase_result_tescase_name_and_count(self):
+        r = mbed_test_api.get_testcase_result(self.OUTOUT_CSTRING_TEST_CASE_COUNT_AND_NAME)
+        self.assertEqual(len(r), 2)
+
+        self.assertIn('C strings: strpbrk', r)
+        self.assertIn('C strings: strtok', r)
+
+        self.assertEqual(r['C strings: strpbrk']['result_text'], 'SKIPPED')
+        self.assertEqual(r['C strings: strtok']['result_text'], 'ERROR')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Changes
* Add support for new `utest` events `__testcase_count` and `__testcase_name`.
* Add support in code for `SKIPPED` test case result in test results.
  * Now if `utest` will provide information about test case names (see events above) we can use this to update list of all test cases missing from log with status `SKIPPED`. See below:
* JUNIT report will be now decorated with SKIPPED test cases so we can actually check how many were dropped during testing. This will allow us to generate reports with test cases count for: tests passed, failed and skipped (so we can get total too!) :) No test case left behind!

JUnit node `<system-out>` will have full `htrun` log, `<system-err>` will hold full `utest` log for particilar test case. For SKIPPED test cases

## Impact
* mbed-os: [ Provide list of test case names to greentea prior to running test. #1 ](https://github.com/adbridge/mbed-os/pull/1)
* Greentea: [Add support for SKIPPED test cases #158 ](https://github.com/ARMmbed/greentea/pull/158)
* greentea-client: [Add new key "__testcase_name". #15 ](https://github.com/ARMmbed/greentea-client/pull/15)
* htrun: [Add new event name __testcase_name #106 ](https://github.com/ARMmbed/htrun/pull/106)

## How to check this PR
```
$ git clone https://github.com/ARMmbed/greentea.git
$ cd greentea
$ git checkout devel_testcase_name
$ python setup.py develop
```

## Example of SKIPPED
Test case `test_case_c_string_strtok` had a divide by zero error and other test had failing ASSERT.

```
$ mbedgt -VS -n mbed-drivers-test-xxx --report-junit xxx.xml
```
```c
Case cases[] = {
    Case("C strings: strtok", test_case_c_string_strtok, greentea_failure_handler),
    Case("C strings: strpbrk", test_case_c_string_strpbrk, greentea_failure_handler),
};
```

```xml
<?xml version="1.0" ?>
<testsuites errors="1" failures="0" tests="2" time="0.0">
	<testsuite errors="1" failures="0" name="frdm-k64f-gcc" skipped="1" tests="2" time="0">
		<properties>
			<property name="toolchain" value="frdm-k64f-gcc"/>
			<property name="name" value="frdm-k64f-gcc"/>
			<property name="target" value="K64F"/>
		</properties>
		<testcase classname="frdm-k64f-gcc.mbed-drivers-test-xxx" name="C strings: strpbrk">
		<testcase classname="frdm-k64f-gcc.mbed-drivers-test-xxx" name="C strings: strtok">
	</testsuite>
</testsuites>
```

```
mbedgt: using 'module.json' from current directory!
mbedgt: checking for yotta target in current directory
        reason: no --target switch set
mbedgt: parsing local file '.yotta.json' for target information
mbedgt: assuming default target as 'frdm-k64f-gcc'
mbedgt: detecting connected mbed-enabled devices...
mbedgt: detected 4 devices
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
        | platform_name | platform_name_unique | serial_port | mount_point | target_id                                        |
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
        | NUCLEO_F401RE | NUCLEO_F401RE[0]     | COM163      | E:          | 07200200076165023804F31F                         |
        | K64F          | K64F[0]              | COM219      | F:          | 0240000033514e450019500585d40008e981000097969900 |
        | K64F          | K64F[1]              | COM229      | G:          | 0240000033514e450040500585d4000be981000097969900 |
        | K64F          | K64F[2]              | COM244      | H:          | 0240000028634e45003350066917001f5f21000097969900 |
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
mbedgt: processing target 'K64F' toolchain 'frdm-k64f-gcc' compatible platforms... (note: switch set to --parallel 1)
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
        | platform_name | platform_name_unique | serial_port | mount_point | target_id                                        |
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
        | K64F          | K64F[0]              | COM219:9600 | F:          | 0240000033514e450019500585d40008e981000097969900 |
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
mbedgt: test case filter (specified with -n option)
        test filtered in 'mbed-drivers-test-xxx'
mbedgt: running 1 test for platform 'K64F' and toolchain 'frdm-k64f-gcc'
        use 1 instance for testing
mbedgt: selecting test case observer...
        calling mbedhtrun: mbedhtrun -d F: -p COM219:9600 -f ".\build\frdm-k64f-gcc\test\mbed-drivers-test-xxx.bin" -C 4 -c shell -m K64F -t 0240000033514e450019500585d40008e981000097969900 -e "./test/host_tests"
mbedgt: mbed-host-test-runner: started
[1467204439.16][HTST][INF] host test executor ver. 0.2.19
[1467204439.16][HTST][INF] copy image onto target...
        1 file(s) copied.
Plugin info: HostTestPluginCopyMethod_Shell::CopyMethod: Waiting up to 60 sec for '0240000033514e450019500585d40008e981000097969900' mount point (current is 'F:')...
[1467204447.66][HTST][INF] starting host test process...
[1467204448.22][CONN][INF] starting serial connection process...
[1467204448.22][CONN][INF] notify event queue about extra 60 sec timeout for serial port pooling
[1467204448.22][CONN][INF] initializing serial port listener...
[1467204448.22][HTST][INF] setting timeout to: 60 sec
[1467204448.22][SERI][INF] serial(port=COM219, baudrate=9600, timeout=0)
Plugin info: HostTestPluginBase::BasePlugin: Waiting up to 60 sec for '0240000033514e450019500585d40008e981000097969900' serial port (current is 'COM219')...
[1467204448.30][SERI][INF] reset device using 'default' plugin...
[1467204448.55][SERI][INF] waiting 1.00 sec after reset
[1467204449.55][SERI][INF] wait for it...
[1467204449.55][SERI][TXD] mbedmbedmbedmbedmbedmbedmbedmbedmbedmbed
[1467204449.55][CONN][INF] sending up to 2 __sync packets (specified with --sync=2)
[1467204449.55][CONN][INF] sending preamble 'c4343f4b-e1a8-4577-9aca-6730a8517154'
[1467204449.55][SERI][TXD] {{__sync;c4343f4b-e1a8-4577-9aca-6730a8517154}}
[1467204449.69][CONN][RXD] {{__sync;c4343f4b-e1a8-4577-9aca-6730a8517154}}
[1467204449.69][CONN][INF] found SYNC in stream: {{__sync;c4343f4b-e1a8-4577-9aca-6730a8517154}} it is #0 sent, queued...
[1467204449.69][HTST][INF] sync KV found, uuid=c4343f4b-e1a8-4577-9aca-6730a8517154, timestamp=1467204449.694000
[1467204449.71][CONN][RXD] {{__version;1.1.0}}
[1467204449.71][CONN][INF] found KV pair in stream: {{__version;1.1.0}}, queued...
[1467204449.71][HTST][INF] DUT greentea-client version: 1.1.0
[1467204449.73][CONN][RXD] {{__timeout;5}}
[1467204449.73][CONN][INF] found KV pair in stream: {{__timeout;5}}, queued...
[1467204449.73][HTST][INF] setting timeout to: 5 sec
[1467204449.76][CONN][RXD] {{__host_test_name;default_auto}}
[1467204449.76][CONN][INF] found KV pair in stream: {{__host_test_name;default_auto}}, queued...
[1467204449.76][HTST][INF] host test class: '<class 'mbed_host_tests.host_tests.default_auto.DefaultAuto'>'
[1467204449.76][HTST][INF] host test setup() call...
[1467204449.76][HTST][INF] CALLBACKs updated
[1467204449.76][HTST][INF] host test detected: default_auto
[1467204449.78][CONN][RXD] {{__testcase_count;2}}
[1467204449.79][CONN][INF] found KV pair in stream: {{__testcase_count;2}}, queued...
[1467204449.81][CONN][RXD] >>> Running 2 test cases...
[1467204449.85][CONN][RXD] {{__testcase_name;C strings: strtok}}
[1467204449.85][CONN][INF] found KV pair in stream: {{__testcase_name;C strings: strtok}}, queued...
[1467204449.89][CONN][RXD] {{__testcase_name;C strings: strpbrk}}
[1467204449.90][CONN][INF] found KV pair in stream: {{__testcase_name;C strings: strpbrk}}, queued...
[1467204449.94][CONN][RXD] >>> Running case #1: 'C strings: strtok'...
[1467204449.98][CONN][RXD] {{__testcase_start;C strings: strtok}}
[1467204449.98][CONN][INF] found KV pair in stream: {{__testcase_start;C strings: strtok}}, queued...
[1467204454.74][HTST][INF] test suite run finished after 5.00 sec...
[1467204454.74][CONN][INF] received special even '__host_test_finished' value='True', finishing
[1467204454.76][HTST][INF] CONN exited with code: 0
[1467204454.76][HTST][INF] No events in queue
[1467204454.76][HTST][INF] stopped consuming events
[1467204454.76][HTST][INF] host test result(): None
[1467204454.76][HTST][WRN] missing __exit event from DUT
[1467204454.76][HTST][ERR] missing __exit event from DUT and no result from host test, timeout...
[1467204454.76][HTST][INF] calling blocking teardown()
[1467204454.76][HTST][INF] teardown() finished
[1467204454.76][HTST][INF] {{result;timeout}}
mbedgt: checking for GCOV data...
mbedgt: mbed-host-test-runner: stopped
mbedgt: mbed-host-test-runner: returned 'TIMEOUT'
mbedgt: test on hardware with target id: 0240000033514e450019500585d40008e981000097969900
mbedgt: test suite 'mbed-drivers-test-xxx' ........................................................... TIMEOUT in 16.21 sec
        test case: 'C strings: strpbrk' .............................................................. SKIPPED in 0.00 sec
        test case: 'C strings: strtok' ............................................................... ERROR in 0.00 sec
mbedgt: all tests finished!
mbedgt: shuffle seed: 0.2155912424
mbedgt: exporting to JUNIT file 'xxx.xml'...
mbedgt: test suite report:
+---------------+---------------+-----------------------+---------+--------------------+-------------+
| target        | platform_name | test suite            | result  | elapsed_time (sec) | copy_method |
+---------------+---------------+-----------------------+---------+--------------------+-------------+
| frdm-k64f-gcc | K64F          | mbed-drivers-test-xxx | TIMEOUT | 16.21              | shell       |
+---------------+---------------+-----------------------+---------+--------------------+-------------+
mbedgt: test suite results: 1 TIMEOUT
mbedgt: test case report:
+---------------+---------------+-----------------------+--------------------+--------+--------+---------+--------------------+
| target        | platform_name | test suite            | test case          | passed | failed | result  | elapsed_time (sec) |
+---------------+---------------+-----------------------+--------------------+--------+--------+---------+--------------------+
| frdm-k64f-gcc | K64F          | mbed-drivers-test-xxx | C strings: strpbrk | 0      | 0      | SKIPPED | 0.0                |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-xxx | C strings: strtok  | 0      | 0      | ERROR   | 0.0                |
+---------------+---------------+-----------------------+--------------------+--------+--------+---------+--------------------+
mbedgt: test case results: 1 SKIPPED / 1 ERROR
mbedgt: completed in 16.36 sec
mbedgt: exited with code 1
```

## Example of OK case
```
mbedgt: checking for GCOV data...
mbedgt: mbed-host-test-runner: stopped
mbedgt: mbed-host-test-runner: returned 'OK'
mbedgt: test on hardware with target id: 0240000033514e450019500585d40008e981000097969900
mbedgt: test suite 'mbed-drivers-test-xxx' ........................................................... OK in 11.98 sec
        test case: 'C strings: strpbrk' .............................................................. OK in 0.05 sec
        test case: 'C strings: strtok' ............................................................... OK in 0.05 sec
mbedgt: test case summary: 2 passes, 0 failures
mbedgt: all tests finished!
mbedgt: shuffle seed: 0.1690637153
mbedgt: exporting to JUNIT file 'xxx.xml'...
mbedgt: test suite report:
+---------------+---------------+-----------------------+--------+--------------------+-------------+
| target        | platform_name | test suite            | result | elapsed_time (sec) | copy_method |
+---------------+---------------+-----------------------+--------+--------------------+-------------+
| frdm-k64f-gcc | K64F          | mbed-drivers-test-xxx | OK     | 11.98              | shell       |
+---------------+---------------+-----------------------+--------+--------------------+-------------+
mbedgt: test suite results: 1 OK
mbedgt: test case report:
+---------------+---------------+-----------------------+--------------------+--------+--------+--------+--------------------+
| target        | platform_name | test suite            | test case          | passed | failed | result | elapsed_time (sec) |
+---------------+---------------+-----------------------+--------------------+--------+--------+--------+--------------------+
| frdm-k64f-gcc | K64F          | mbed-drivers-test-xxx | C strings: strpbrk | 1      | 0      | OK     | 0.05               |
| frdm-k64f-gcc | K64F          | mbed-drivers-test-xxx | C strings: strtok  | 1      | 0      | OK     | 0.05               |
+---------------+---------------+-----------------------+--------------------+--------+--------+--------+--------------------+
mbedgt: test case results: 2 OK
mbedgt: completed in 12.15 sec
```

```xml
<?xml version="1.0" ?>
<testsuites errors="0" failures="0" tests="2" time="0.0999999046326">
	<testsuite errors="0" failures="0" name="frdm-k64f-gcc" skipped="0" tests="2" time="0.0999999046326">
	</testsuite>
</testsuites>
```
