### PR TITLE
Add support for command line switch --grm between greentea and htrun

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -610,6 +610,20 @@ def main_cli(opts, args, gt_instance_uuid=None):
                 ready_mbed_devices.append(mut)
         return (ready_mbed_devices, not_ready_mbed_devices)
 
+    def get_parallel_value(value):
+        """! Get correct value for parallel switch (--parallel)
+        @param value Value passed from --parallel
+        @return Refactored version of parallel number
+        """
+        try:
+            parallel_test_exec = int(value)
+            if parallel_test_exec < 1:
+                parallel_test_exec = 1
+        except ValueError:
+            gt_logger.gt_log_err("argument of mode --parallel is not a int, disabled parallel mode")
+            parallel_test_exec = 1
+        return parallel_test_exec
+
     if not MBED_LMTOOLS:
         gt_logger.gt_log_err("error: mbed-ls proprietary module not installed")
         return (-1)
@@ -711,13 +725,8 @@ def main_cli(opts, args, gt_instance_uuid=None):
     execute_threads = []        # list of threads to run test cases
 
     ### check if argument of --parallel mode is a integer and greater or equal 1
-    try:
-        parallel_test_exec = int(opts.parallel_test_exec)
-        if parallel_test_exec < 1:
-            parallel_test_exec = 1
-    except ValueError:
-        gt_logger.gt_log_err("argument of mode --parallel is not a int, disable parallel mode")
-        parallel_test_exec = 1
+
+    parallel_test_exec = get_parallel_value(opts.parallel_test_exe)
 
     # Values used to generate random seed for test execution order shuffle
     SHUFFLE_SEED_ROUND = 10 # Value used to round float random seed

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -34,6 +34,7 @@ from mbed_greentea.mbed_test_api import run_host_test
 from mbed_greentea.mbed_test_api import log_mbed_devices_in_table
 from mbed_greentea.mbed_test_api import TEST_RESULTS
 from mbed_greentea.mbed_test_api import TEST_RESULT_OK, TEST_RESULT_FAIL
+from mbed_greentea.mbed_test_api import parse_global_resource_mgr
 from mbed_greentea.mbed_report_api import exporter_text
 from mbed_greentea.mbed_report_api import exporter_testcase_text
 from mbed_greentea.mbed_report_api import exporter_json
@@ -241,6 +242,10 @@ def main():
                     action="store_true",
                     help='List available binaries')
 
+    parser.add_option('-g', '--grm',
+                    dest='global_resource_mgr',
+                    help='Global resource manager service query: platrform name, remote mgr module name, IP address and port, example K64F:module_name:10.2.123.43:3334')
+
     parser.add_option('-m', '--map-target',
                     dest='map_platform_to_yt_target',
                     help='List of custom mapping between platform name and yotta target. Comma separated list of YOTTA_TARGET:PLATFORM tuples')
@@ -420,6 +425,7 @@ def run_test_thread(test_result_queue, test_queue, opts, mut, build, build_path,
                                          digest_source=opts.digest_source,
                                          json_test_cfg=opts.json_test_configuration,
                                          enum_host_tests_path=enum_host_tests_path,
+                                         global_resource_mgr=opts.global_resource_mgr,
                                          verbose=verbose)
 
         # Some error in htrun, abort test execution
@@ -658,6 +664,20 @@ def main_cli(opts, args, gt_instance_uuid=None):
     # Detect devices connected to system
     mbeds = mbed_lstools.create()
     mbeds_list = mbeds.list_mbeds_ext()
+
+    if opts.global_resource_mgr:
+        # Mocking available platform requested by --grm switch
+        grm_values = parse_global_resource_mgr(opts.global_resource_mgr)
+        if grm_values:
+            gt_logger.gt_log_warn("entering global resource manager mbed-ls dummy mode!")
+            grm_platform_name, grm_module_name, grm_ip_name, grm_port_name = grm_values
+            mbeds_list = []
+            mbeds_list.append(mbeds.get_dummy_platform(grm_platform_name))
+            opts.global_resource_mgr = ':'.join(grm_values[1:])
+            gt_logger.gt_log_tab("adding dummy platform '%s'"% grm_platform_name)
+        else:
+            gt_logger.gt_log("global resource manager switch '--grm %s' in wrong format!"% opts.global_resource_mgr)
+            return (-1)
 
     ready_mbed_devices = [] # Devices which can be used (are fully detected)
     not_ready_mbed_devices = [] # Devices which can't be used (are not fully detected)

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -726,7 +726,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
 
     ### check if argument of --parallel mode is a integer and greater or equal 1
 
-    parallel_test_exec = get_parallel_value(opts.parallel_test_exe)
+    parallel_test_exec = get_parallel_value(opts.parallel_test_exec)
 
     # Values used to generate random seed for test execution order shuffle
     SHUFFLE_SEED_ROUND = 10 # Value used to round float random seed


### PR DESCRIPTION
### Changes
* Add `mbed-ls` dummy platform used for triggering workflow for glbal resource manager
  * See https://github.com/ARMmbed/mbed-ls/pull/107
* Add command line switch `--grm` which will be passed to `htrun` for global resource allocation
  * Example: `--grm K64F:raas_client:10.2.302.41:8000`
* Supporting for https://github.com/ARMmbed/htrun/pull/108

### Usage

Calling global resource manager from Greentea command line requires:
* Greentea must be called from the same directory yuou would call any non-remote (local) tests
* Greentea must find tests in range, please use `$ mbedgt --list` to verify you can access tests
* You must provide explicitly Greentea command line switches: `--grm`
  * You can mix it with for example: `-V`, `-t`, `-n`, `---report-junit`
* You must explicitly specify with switch `--grm`:
  * Platform name you want to use for testing with remote access
  * Remote resource manager Python module name
  * IP and port of remote resource manager service
  * Example: `--grm K64F:raas_client:10.2.203.31:8000`

### End-2-end Example
```
$ mbedgt --list
mbedgt: greentea test automation tool ver. 1.0.1
mbedgt: using multiple test specifications from current directory!
        using '.build\tests\K64F\ARM\test_spec.json'
        using '.build\tests\K64F\GCC_ARM\test_spec.json'
        using '.build\tests\K64F\IAR\test_spec.json'
mbedgt: available tests for built 'K64F-GCC_ARM', location '.build/tests/K64F/GCC_ARM'
        test 'tests-mbed_drivers-c_strings'
        test 'tests-mbed_drivers-callback'
        test 'tests-mbed_drivers-echo'
        test 'tests-mbed_drivers-generic_tests'
mbedgt: available tests for built 'K64F-ARM', location '.build/tests/K64F/ARM'
        test 'tests-mbed_drivers-c_strings'
        test 'tests-mbed_drivers-callback'
        test 'tests-mbed_drivers-echo'
        test 'tests-mbed_drivers-generic_tests'
mbedgt: available tests for built 'K64F-IAR', location '.build/tests/K64F/IAR'
        test 'tests-mbed_drivers-c_strings'
        test 'tests-mbed_drivers-callback'
        test 'tests-mbed_drivers-echo'
        test 'tests-mbed_drivers-generic_tests'
```

* We have three builds: `K64F-GCC_ARM`, `K64F-ARM`, `K64F-IAR`
  * `$ mbedgt -V`is equivalent to `$ mbedgt -V -t K64F-GCC_ARM,K64F-ARM,K64F-IAR` and will run all tests for all three builds in our example.
  * `$ mbedgt -V -t K64F-ARM` will run all tests under `K64F-ARM` build.
  * `$ mbedgt -V -t K64F-ARM -n tests-mbed_drivers-c*` will run all tests with names starting with `tests-mbed_drivers-c` under `K64F-ARM` build.

Example output from run with remote resource manager: [x04.xml.txt](https://github.com/ARMmbed/greentea/files/352247/x04.xml.txt)
