### PR TITLE
Response for #167 (suppress logs in non -V mode

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -656,6 +656,9 @@ def main_cli(opts, args, gt_instance_uuid=None):
     if not test_spec:
         return ret
 
+    # Verbose flag
+    verbose = opts.verbose_test_result_only
+
     # We will load hooks from JSON file to support extra behaviour during test execution
     greentea_hooks = GreenteaHooks(opts.hooks_json) if opts.hooks_json else None
 
@@ -670,7 +673,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
                                          hooks=greentea_hooks,
                                          digest_source=opts.digest_source,
                                          enum_host_tests_path=enum_host_tests_path,
-                                         verbose=opts.verbose_test_result_only)
+                                         verbose=verbose)
 
         # Some error in htrun, abort test execution
         if isinstance(host_test_result, int):
@@ -712,7 +715,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
         if ready_mbed_devices:
             # devices in form of a pretty formatted table
             for line in log_mbed_devices_in_table(ready_mbed_devices).splitlines():
-                gt_logger.gt_log_tab(line.strip())
+                gt_logger.gt_log_tab(line.strip(), print_text=verbose)
     else:
         gt_logger.gt_log_err("no compatible devices detected")
         return (RET_NO_DEVICES)
@@ -749,7 +752,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
 
     ### Testing procedures, for each target, for each target's compatible platform
     # In case we are using test spec (switch --test-spec) command line option -t <list_of_targets>
-    # is used to enumerate builds from test spec we are suppling
+    # is used to enumerate builds from test spec we are supplying
     filter_test_builds = opts.list_of_targets.split(',') if opts.list_of_targets else None
     for test_build in test_spec.get_test_builds(filter_test_builds):
         platform_name = test_build.get_platform()
@@ -782,7 +785,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
 
         # devices in form of a pretty formatted table
         for line in log_mbed_devices_in_table(muts_to_test).splitlines():
-            gt_logger.gt_log_tab(line.strip())
+            gt_logger.gt_log_tab(line.strip(), print_text=verbose)
 
         # Configuration print mode:
         if opts.verbose_test_configuration_only:
@@ -870,7 +873,8 @@ def main_cli(opts, args, gt_instance_uuid=None):
                     execute_threads.append(t)
                     number_of_threads += 1
 
-        gt_logger.gt_log_tab("use %s instance%s for testing" % (len(execute_threads), 's' if len(execute_threads) != 1 else ''))
+        gt_logger.gt_log_tab("use %s instance%s of execution threads for testing"% (len(execute_threads),
+            's' if len(execute_threads) != 1 else str()), print_text=verbose)
         for t in execute_threads:
             t.daemon = True
             t.start()

--- a/mbed_greentea/mbed_greentea_log.py
+++ b/mbed_greentea/mbed_greentea_log.py
@@ -107,12 +107,15 @@ class GreenTeaSimpleLockLogger:
             self.__print(result)
         return result
 
-    def gt_log_tab(self, text, tab_count=1):
+    def gt_log_tab(self, text, tab_count=1, print_text=True):
         """! Prints standard log message with one (1) tab margin on the left
+        @param tab_count How many tags should be added (indent level)
+        @param print_text Forces log function to print on screen (not only return message)
         @return Returns string with message
         """
         result = "\t"*tab_count + text
-        self.__print(result)
+        if print_text:
+            self.__print(result)
         return result
 
     def gt_log_err(self, text, print_text=True):

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -193,7 +193,7 @@ def run_host_test(image_path,
         #
         # If host_tests directory is found above test code will will pass it to mbedhtrun using
         # switch -e <path_to_host_tests_dir>
-        gt_logger.gt_log("checking for 'host_tests' directory above image directory structure")
+        gt_logger.gt_log("checking for 'host_tests' directory above image directory structure", print_text=verbose)
         test_group_ht_path = get_binary_host_tests_dir(image_path, level=2)
         TESTS_dir_ht_path = get_binary_host_tests_dir(image_path, level=3)
         if test_group_ht_path:
@@ -202,9 +202,9 @@ def run_host_test(image_path,
             enum_host_tests_path = TESTS_dir_ht_path
 
         if enum_host_tests_path:
-            gt_logger.gt_log_tab("found 'host_tests' directory in: '%s'"% enum_host_tests_path)
+            gt_logger.gt_log_tab("found 'host_tests' directory in: '%s'"% enum_host_tests_path, print_text=verbose)
         else:
-            gt_logger.gt_log_tab("'host_tests' directory not found: two directory levels above image path checked")
+            gt_logger.gt_log_tab("'host_tests' directory not found: two directory levels above image path checked", print_text=verbose)
 
     if verbose:
         gt_logger.gt_log("selecting test case observer...")
@@ -601,7 +601,7 @@ def get_test_spec(opts):
         else:
             test_spec = get_test_spec_from_yt_module(opts)
     else:
-        gt_logger.gt_log_err("greentea should be run inside a Yotta module or --test-spec switch should be used.")
+        gt_logger.gt_log_err("greentea should be run inside a Yotta module or --test-spec switch should be used")
         return None, -1
     return test_spec, 0
 

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -206,10 +206,9 @@ def run_host_test(image_path,
         else:
             gt_logger.gt_log_tab("'host_tests' directory not found: two directory levels above image path checked", print_text=verbose)
 
-    if verbose:
-        gt_logger.gt_log("selecting test case observer...")
-        if digest_source:
-            gt_logger.gt_log_tab("selected digest source: %s"% digest_source)
+    gt_logger.gt_log("selecting test case observer...", print_text=verbose)
+    if digest_source:
+        gt_logger.gt_log_tab("selected digest source: %s"% digest_source, print_text=verbose)
 
     # Select who will digest test case serial port data
     if digest_source == 'stdin':
@@ -255,8 +254,7 @@ def run_host_test(image_path,
         if enum_host_tests_path:
             cmd += ["-e", '"%s"'% enum_host_tests_path]
 
-    if verbose:
-        gt_logger.gt_log_tab("calling mbedhtrun: %s"% " ".join(cmd))
+    gt_logger.gt_log_tab("calling mbedhtrun: %s"% " ".join(cmd), print_text=verbose)
     gt_logger.gt_log("mbed-host-test-runner: started")
 
     htrun_output = str()
@@ -289,9 +287,7 @@ def run_host_test(image_path,
     test_cases_summary = get_testcase_summary(htrun_output)
     get_coverage_data(build_path, htrun_output)
 
-    if verbose:
-        gt_logger.gt_log("mbed-host-test-runner: stopped")
-        gt_logger.gt_log("mbed-host-test-runner: returned '%s'"% result)
+    gt_logger.gt_log("mbed-host-test-runner: stopped and returned '%s'"% result, print_text=verbose)
     return (result, htrun_output, testcase_duration, duration, result_test_cases, test_cases_summary)
 
 def get_testcase_count_and_names(output):


### PR DESCRIPTION
# Changes
* Response for #167 (suppress logs in non-verbose `-V` switch mode)
* Changed few logs to be suppressed when executing Greentea without `-V` flag.
* Add `print_text` to logger `gt_log_tab()` function. Now we can steer logging e.g. without awkward:
```python
if verbose:
    logger.gt_log_tab("TEXT")
```
but with more convenient:
```python
logger.gt_log_tab("TEXT", print_text=verbose)
```

## Test run without -V in new format
```
$ mbedgt -n tests-mbed_drivers-generic_tests
```
```
mbedgt: greentea test automation tool ver. 1.1.1
mbedgt: using multiple test specifications from current directory!
        using '.build\tests\K64F\GCC_ARM\test_spec.json'
mbedgt: detecting connected mbed-enabled devices...
mbedgt: detected 1 device
mbedgt: processing target 'K64F' toolchain 'GCC_ARM' compatible platforms... (note: switch set to --parallel 1)
mbedgt: test case filter (specified with -n option)
        test filtered in 'tests-mbed_drivers-generic_tests'
mbedgt: running 1 test for platform 'K64F' and toolchain 'GCC_ARM'
mbedgt: mbed-host-test-runner: started
mbedgt: checking for GCOV data...
mbedgt: test on hardware with target id: 0240000033514e450040500585d4000be981000097969900
mbedgt: test suite 'tests-mbed_drivers-generic_tests' ................................................ OK in 13.17 sec
        test case: 'Basic' ........................................................................... OK in 0.03 sec
        test case: 'Blinky' .......................................................................... OK in 0.03 sec
        test case: 'C++ heap' ........................................................................ OK in 0.09 sec
        test case: 'C++ stack' ....................................................................... OK in 0.15 sec
mbedgt: test case summary: 4 passes, 0 failures
mbedgt: all tests finished!
mbedgt: shuffle seed: 0.1179348016
mbedgt: test suite report:
+--------------+---------------+----------------------------------+--------+--------------------+-------------+
| target       | platform_name | test suite                       | result | elapsed_time (sec) | copy_method |
+--------------+---------------+----------------------------------+--------+--------------------+-------------+
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-generic_tests | OK     | 13.17              | shell       |
+--------------+---------------+----------------------------------+--------+--------------------+-------------+
mbedgt: test suite results: 1 OK
mbedgt: test case report:
+--------------+---------------+----------------------------------+-----------+--------+--------+--------+--------------------+
| target       | platform_name | test suite                       | test case | passed | failed | result | elapsed_time (sec) |
+--------------+---------------+----------------------------------+-----------+--------+--------+--------+--------------------+
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-generic_tests | Basic     | 1      | 0      | OK     | 0.03               |
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-generic_tests | Blinky    | 1      | 0      | OK     | 0.03               |
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-generic_tests | C++ heap  | 1      | 0      | OK     | 0.09               |
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-generic_tests | C++ stack | 1      | 0      | OK     | 0.15               |
+--------------+---------------+----------------------------------+-----------+--------+--------+--------+--------------------+
mbedgt: test case results: 4 OK
mbedgt: completed in 13.31 sec
```

## Test run with -V in new format
```
mbedgt -V -n tests-mbed_drivers-generic_tests
```
```
mbedgt: greentea test automation tool ver. 1.1.1
mbedgt: using multiple test specifications from current directory!
        using '.build\tests\K64F\GCC_ARM\test_spec.json'
mbedgt: detecting connected mbed-enabled devices...
mbedgt: detected 1 device
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
        | platform_name | platform_name_unique | serial_port | mount_point | target_id                                        |
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
        | K64F          | K64F[0]              | COM229      | G:          | 0240000033514e450040500585d4000be981000097969900 |
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
mbedgt: processing target 'K64F' toolchain 'GCC_ARM' compatible platforms... (note: switch set to --parallel 1)
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
        | platform_name | platform_name_unique | serial_port | mount_point | target_id                                        |
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
        | K64F          | K64F[0]              | COM229:9600 | G:          | 0240000033514e450040500585d4000be981000097969900 |
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
mbedgt: test case filter (specified with -n option)
        test filtered in 'tests-mbed_drivers-generic_tests'
mbedgt: running 1 test for platform 'K64F' and toolchain 'GCC_ARM'
        use 1 instance of execution threads for testing
mbedgt: checking for 'host_tests' directory above image directory structure
        'host_tests' directory not found: two directory levels above image path checked
mbedgt: selecting test case observer...
        calling mbedhtrun: mbedhtrun -m K64F -p COM229:9600 -f ".build/tests/K64F/GCC_ARM/TESTS/mbed_drivers/generic_tests/generic_tests.bin" -d G: -C 4 -c shell -t 0240000033514e450040500585d4000be981000097969900
mbedgt: mbed-host-test-runner: started

[HTRUN LOG]

mbedgt: checking for GCOV data...
mbedgt: mbed-host-test-runner: stopped and returned 'OK'
mbedgt: test on hardware with target id: 0240000033514e450040500585d4000be981000097969900
mbedgt: test suite 'tests-mbed_drivers-generic_tests' ................................................ OK in 13.16 sec
        test case: 'Basic' ........................................................................... OK in 0.04 sec
        test case: 'Blinky' .......................................................................... OK in 0.03 sec
        test case: 'C++ heap' ........................................................................ OK in 0.10 sec
        test case: 'C++ stack' ....................................................................... OK in 0.16 sec
mbedgt: test case summary: 4 passes, 0 failures
mbedgt: all tests finished!
mbedgt: shuffle seed: 0.3694399963
mbedgt: test suite report:
+--------------+---------------+----------------------------------+--------+--------------------+-------------+
| target       | platform_name | test suite                       | result | elapsed_time (sec) | copy_method |
+--------------+---------------+----------------------------------+--------+--------------------+-------------+
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-generic_tests | OK     | 13.16              | shell       |
+--------------+---------------+----------------------------------+--------+--------------------+-------------+
mbedgt: test suite results: 1 OK
mbedgt: test case report:
+--------------+---------------+----------------------------------+-----------+--------+--------+--------+--------------------+
| target       | platform_name | test suite                       | test case | passed | failed | result | elapsed_time (sec) |
+--------------+---------------+----------------------------------+-----------+--------+--------+--------+--------------------+
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-generic_tests | Basic     | 1      | 0      | OK     | 0.04               |
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-generic_tests | Blinky    | 1      | 0      | OK     | 0.03               |
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-generic_tests | C++ heap  | 1      | 0      | OK     | 0.1                |
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-generic_tests | C++ stack | 1      | 0      | OK     | 0.16               |
+--------------+---------------+----------------------------------+-----------+--------+--------+--------+--------------------+
mbedgt: test case results: 4 OK
mbedgt: completed in 13.35 sec
```

# Old format
## Test run no-verbose
```
mbedgt -n tests-mbed_drivers-generic_tests
```
```
mbedgt: greentea test automation tool ver. 1.1.1
mbedgt: using multiple test specifications from current directory!
        using '.build\tests\K64F\GCC_ARM\test_spec.json'
mbedgt: detecting connected mbed-enabled devices...
mbedgt: detected 1 device
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
        | platform_name | platform_name_unique | serial_port | mount_point | target_id                                        |
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
        | K64F          | K64F[0]              | COM229      | G:          | 0240000033514e450040500585d4000be981000097969900 |
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
mbedgt: processing target 'K64F' toolchain 'GCC_ARM' compatible platforms... (note: switch set to --parallel 1)
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
        | platform_name | platform_name_unique | serial_port | mount_point | target_id                                        |
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
        | K64F          | K64F[0]              | COM229:9600 | G:          | 0240000033514e450040500585d4000be981000097969900 |
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
mbedgt: test case filter (specified with -n option)
        test filtered in 'tests-mbed_drivers-generic_tests'
mbedgt: running 1 test for platform 'K64F' and toolchain 'GCC_ARM'
        use 1 instance for testing
mbedgt: checking for 'host_tests' directory above image directory structure
        'host_tests' directory not found: two directory levels above image path checked
mbedgt: mbed-host-test-runner: started
mbedgt: checking for GCOV data...
mbedgt: test on hardware with target id: 0240000033514e450040500585d4000be981000097969900
mbedgt: test suite 'tests-mbed_drivers-generic_tests' ................................................ OK in 13.15 sec
        test case: 'Basic' ........................................................................... OK in 0.03 sec
        test case: 'Blinky' .......................................................................... OK in 0.03 sec
        test case: 'C++ heap' ........................................................................ OK in 0.09 sec
        test case: 'C++ stack' ....................................................................... OK in 0.15 sec
mbedgt: test case summary: 4 passes, 0 failures
mbedgt: all tests finished!
mbedgt: shuffle seed: 0.0975754326
mbedgt: test suite report:
+--------------+---------------+----------------------------------+--------+--------------------+-------------+
| target       | platform_name | test suite                       | result | elapsed_time (sec) | copy_method |
+--------------+---------------+----------------------------------+--------+--------------------+-------------+
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-generic_tests | OK     | 13.15              | shell       |
+--------------+---------------+----------------------------------+--------+--------------------+-------------+
mbedgt: test suite results: 1 OK
mbedgt: test case report:
+--------------+---------------+----------------------------------+-----------+--------+--------+--------+--------------------+
| target       | platform_name | test suite                       | test case | passed | failed | result | elapsed_time (sec) |
+--------------+---------------+----------------------------------+-----------+--------+--------+--------+--------------------+
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-generic_tests | Basic     | 1      | 0      | OK     | 0.03               |
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-generic_tests | Blinky    | 1      | 0      | OK     | 0.03               |
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-generic_tests | C++ heap  | 1      | 0      | OK     | 0.09               |
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-generic_tests | C++ stack | 1      | 0      | OK     | 0.15               |
+--------------+---------------+----------------------------------+-----------+--------+--------+--------+--------------------+
mbedgt: test case results: 4 OK
mbedgt: completed in 13.31 sec
```

## Test run verbose
(The same as after change)