### PR TITLE
Added reporting to Testlink XML

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -40,6 +40,7 @@ from mbed_greentea.mbed_report_api import exporter_testcase_text
 from mbed_greentea.mbed_report_api import exporter_json
 from mbed_greentea.mbed_report_api import exporter_testcase_junit
 from mbed_greentea.mbed_report_api import exporter_html
+from mbed_greentea.mbed_report_api import exporter_testlink_xml
 from mbed_greentea.mbed_greentea_log import gt_logger
 from mbed_greentea.mbed_greentea_dlm import GREENTEA_KETTLE_PATH
 from mbed_greentea.mbed_greentea_dlm import greentea_get_app_sem
@@ -310,6 +311,10 @@ def main():
     parser.add_option('', '--report-json',
                     dest='report_json_file_name',
                     help='You can log test suite results to JSON formatted file')
+
+    parser.add_option('', '--report-testlink-xml',
+                    dest='report_testlink_xml_file_name',
+                    help='You can log test suite results to a Testlink XML formatted file')
 
     parser.add_option('', '--report-html',
                     dest='report_html_file_name',
@@ -1006,6 +1011,12 @@ def main_cli(opts, args, gt_instance_uuid=None):
             # Generate a HTML page displaying all of the results
             html_report = exporter_html(test_report)
             dump_report_to_text_file(opts.report_html_file_name, html_report)
+
+        if opts.report_testlink_xml_file_name:
+            gt_logger.gt_log("exporting to Testlink XML file '%s'..."% gt_logger.gt_bright(opts.report_testlink_xml_file_name))
+            # Generate a Testlink XML with all of the results
+            testlink_xml_report = exporter_testlink_xml(test_report)
+            dump_report_to_text_file(opts.report_testlink_xml_file_name, testlink_xml_report)
 
         # Final summary
         if test_report:

--- a/mbed_greentea/mbed_report_api.py
+++ b/mbed_greentea/mbed_report_api.py
@@ -244,13 +244,21 @@ def exporter_testlink_xml(test_result_ext, test_suite_properties=None):
                 if testcase['result'] < 0:
                     errors += 1
                 failures += testcase['failed']
-    generator.startElement('testsuite', AttributesImpl({'errors': str(errors), 'failures': str(failures), 'tests': str(tests), 'time': str(time)}))
+    generator.startElement('testsuite', AttributesImpl({
+        'errors': str(errors),
+        'failures': str(failures),
+        'tests': str(tests),
+        'time': str(time)}))
 
     for target_toolcahin, testsuites in test_result_ext.iteritems():
         for testsuite_name, testsuite in testsuites.iteritems():
             for testcase_name, testcase in testsuite['testcase_result'].iteritems():
                 output.write("\n\t".expandtabs(4))
-                generator.startElement('testcase', AttributesImpl({'classname': testcase_name, 'host_os': host_os, 'name': testcase_name, 'time': str(testcase['duration'])}))
+                generator.startElement('testcase', AttributesImpl({
+                    'classname': testcase_name,
+                    'host_os': host_os,
+                    'name': testcase_name,
+                    'time': str(testcase['duration'])}))
                 generator.endElement('testcase')
     output.write("\n")
     generator.endElement('testsuite')


### PR DESCRIPTION
# Changes
* Added exporter to produce report for Testlink in XML format
* Added command line switch `--report-testlink-xml` to output the Testlink XML format to a file