### PR TITLE
Add uniquely MUTs to list of MUTs which will be used for testing

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -782,7 +782,9 @@ def main_cli(opts, args, gt_instance_uuid=None):
                 if not mbed_dev['serial_port'].endswith(str(baudrate)):
                     mbed_dev['serial_port'] = "%s:%d" % (mbed_dev['serial_port'], baudrate)
                 mut = mbed_dev
-                muts_to_test.append(mbed_dev)
+                if mbed_dev not in muts_to_test:
+                    # We will only add unique devices to list of devices "for testing" in this test run
+                    muts_to_test.append(mbed_dev)
                 if number_of_parallel_instances < parallel_test_exec:
                     number_of_parallel_instances += 1
                 else:


### PR DESCRIPTION
# Description
* Fixes #164 - fingers crossed! :P
* Only add MUT to list of MUTs under test when MUT is not on the list.

# Testing
Checked with two builds:
```
+--------------+---------------+-----------------------------+--------+--------------------+-------------+
| target       | platform_name | test suite                  | result | elapsed_time (sec) | copy_method |
+--------------+---------------+-----------------------------+--------+--------------------+-------------+
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-ticker   | OK     | 23.43              | shell       |
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-ticker_2 | OK     | 23.42              | shell       |
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-ticker_3 | OK     | 23.52              | shell       |
| K64F-IAR     | K64F          | tests-mbed_drivers-ticker   | OK     | 21.36              | shell       |
| K64F-IAR     | K64F          | tests-mbed_drivers-ticker_2 | OK     | 21.35              | shell       |
| K64F-IAR     | K64F          | tests-mbed_drivers-ticker_3 | OK     | 21.33              | shell       |
+--------------+---------------+-----------------------------+--------+--------------------+-------------+
mbedgt: test suite results: 6 OK
mbedgt: test case report:
+--------------+---------------+-----------------------------+----------------------+--------+--------+--------+--------------------+
| target       | platform_name | test suite                  | test case            | passed | failed | result | elapsed_time (sec) |
+--------------+---------------+-----------------------------+----------------------+--------+--------+--------+--------------------+
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-ticker   | Timers: 2 x tickers  | 1      | 0      | OK     | 11.05              |
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-ticker_2 | Timers: 1x ticker    | 1      | 0      | OK     | 11.04              |
| K64F-GCC_ARM | K64F          | tests-mbed_drivers-ticker_3 | Timers: 2x callbacks | 1      | 0      | OK     | 11.05              |
| K64F-IAR     | K64F          | tests-mbed_drivers-ticker   | Timers: 2 x tickers  | 1      | 0      | OK     | 11.05              |
| K64F-IAR     | K64F          | tests-mbed_drivers-ticker_2 | Timers: 1x ticker    | 1      | 0      | OK     | 11.04              |
| K64F-IAR     | K64F          | tests-mbed_drivers-ticker_3 | Timers: 2x callbacks | 1      | 0      | OK     | 11.05              |
+--------------+---------------+-----------------------------+----------------------+--------+--------+--------+--------------------+
mbedgt: test case results: 6 OK
mbedgt: completed in 135.14 sec
```

In each run got correct list of MUTs used for testing:
```
mbedgt: detected 2 devices
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
        | platform_name | platform_name_unique | serial_port | mount_point | target_id                                        |
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
        | K64F          | K64F[0]              | COM231      | E:          | 0240000025354e45003f400b47d00039bb91000097969900 |
        | K64F          | K64F[1]              | COM244      | F:          | 0240000028634e45003350066917001f5f21000097969900 |
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
mbedgt: processing target 'K64F' toolchain 'GCC_ARM' compatible platforms... (note: switch set to --parallel 1)
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
        | platform_name | platform_name_unique | serial_port | mount_point | target_id                                        |
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
        | K64F          | K64F[0]              | COM231:9600 | E:          | 0240000025354e45003f400b47d00039bb91000097969900 |
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
```

## "Broke" table before fix
```
mbedgt: processing target 'K64F' toolchain 'IAR' compatible platforms... (note: switch set to --parallel 1)
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
        | platform_name | platform_name_unique | serial_port | mount_point | target_id                                        |
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
        | K64F          | K64F[0]              | COM231:9600 | E:          | 0240000025354e45003f400b47d00039bb91000097969900 |
        | K64F          | K64F[0]              | COM231:9600 | E:          | 0240000025354e45003f400b47d00039bb91000097969900 |
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
```

## "Broken" table after fix
```
mbedgt: processing target 'K64F' toolchain 'IAR' compatible platforms... (note: switch set to --parallel 1)
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
        | platform_name | platform_name_unique | serial_port | mount_point | target_id                                        |
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
        | K64F          | K64F[0]              | COM231:9600 | E:          | 0240000025354e45003f400b47d00039bb91000097969900 |
        +---------------+----------------------+-------------+-------------+--------------------------------------------------+
```