### PR TITLE
Added support for Testlink

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Hello!
-We are an open source project of [ARM mbed](www.mbed.com). Contributions via [pull request](https://github.com/armmbed/yotta/pulls), and [bug reports](https://github.com/armmbed/yotta/issues) are welcome!
+We are an open source project of [ARM mbed](https://www.mbed.com). Contributions via [pull request](https://github.com/armmbed/yotta/pulls), and [bug reports](https://github.com/armmbed/yotta/issues) are welcome!
 
 For more details please see our general [CONTRIBUTING.md](https://github.com/ARMmbed/greentea/blob/master/docs/CONTRIBUTING.md) document.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
       * [Executing all tests](#executing-all-tests)
       * [Cherry-pick tests](#cherry-pick-tests)
       * [Cherry-pick group of tests](#cherry-pick-group-of-tests)
-* [Testlink Integration](#testlink-integration)
+* [Test Plan Integration](#test-plan-integration)
   * [Listing Test Cases](#listing-test-cases)
   * [Test Specification with Test Cases](#test-specification-with-test-cases)
   * [Testlink XML Report](#testlink-xml-report)
@@ -645,12 +645,12 @@ $ mbedgt -V -n mbed-drivers-t*
 $ mbedgt -V -n mbed-drivers-t*,tests-mbed_drivers-rtc
 ```
 
-# Testlink Integration
-Greentea has support for using Testlink to automate the running of tests. Testlink creates a `test_plan.json` file, which is input into Greentea using the `--testlink-test-plan <FILE>` command line switch. This tells Greentea which test cases that it should run, which will be checked against the available test cases. It will then choose the correct test binaries, based on the test cases that they contain. If there are test cases specified in the test plan, that Greentea does not know of, then it will report back all of the test cases that it cannot find.
+# Test Plan Integration
+Greentea has support for using Test Plans to automate the running of tests. Test management systems create a `test_plan.json` file, which is input into Greentea using the `--test-plan <FILE>` command line switch. This tells Greentea which test cases that it should run, which will be checked against the available test cases. It will then choose the correct test binaries, based on the test cases that they contain. If there are test cases specified in the test plan, that Greentea does not know of, then it will report back all of the test cases that it cannot find.
 
 Greentea gets the list of test cases from the `test_spec.json` files that it parses, or has input into it. The test cases are specified in an optional field in the `"binaries"` list, inside `"testcases"`.
 
-The results of the tests can be exported in a junit format, that is compatible to input back into Testlink. It will contain only the test cases that were specified in the Test Plan (if there was one), and any errors that might have occurred. This is retrieved by using the command line switch `--report-testlink-xml <FILE>`.
+The results of the tests can be exported in a JUnit XML format, that is made to be input back into the Test management system. It will contain only the test cases that were specified in the Test Plan (if there was one), and any errors that might have occurred. This is retrieved by using the report command line switch, which is likely to be different for different management systems. Currently Testlink is supported using `--report-testlink-xml <FILE>`.
 
 ## Listing Test Cases
 All of the test cases that are found by Greentea can be listed using the command line switch `--list-test-cases`. This will output all of the test binaries that were found, along with their test cases, if they are specified.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@
       * [Executing all tests](#executing-all-tests)
       * [Cherry-pick tests](#cherry-pick-tests)
       * [Cherry-pick group of tests](#cherry-pick-group-of-tests)
+* [Testlink Integration](#testlink-integration)
+  * [Listing Test Cases](#listing-test-cases)
+  * [Test Specification with Test Cases](#test-specification-with-test-cases)
+  * [Testlink XML Report](#testlink-xml-report)
 * [Using Greentea with new targets](#using-greentea-with-new-targets)
   * [Greentea and yotta targets](#greentea-and-yotta-targets)
   * [Prototyping support](#prototyping-support)
@@ -639,6 +643,65 @@ $ mbedgt -V -n mbed-drivers-t*
 * Filter all tests with names starting with 'mbed-drivers-t' and test case `tests-mbed_drivers-rtc`
 ```
 $ mbedgt -V -n mbed-drivers-t*,tests-mbed_drivers-rtc
+```
+
+# Testlink Integration
+Greentea has support for using Testlink to automate the running of tests. Testlink creates a `test_plan.json` file, which is input into Greentea using the `--testlink-test-plan <FILE>` command line switch. This tells Greentea which test cases that it should run, which will be checked against the available test cases. It will then choose the correct test binaries, based on the test cases that they contain. If there are test cases specified in the test plan, that Greentea does not know of, then it will report back all of the test cases that it cannot find.
+
+Greentea gets the list of test cases from the `test_spec.json` files that it parses, or has input into it. The test cases are specified in an optional field in the `"binaries"` list, inside `"testcases"`.
+
+The results of the tests can be exported in a junit format, that is compatible to input back into Testlink. It will contain only the test cases that were specified in the Test Plan (if there was one), and any errors that might have occurred. This is retrieved by using the command line switch `--report-testlink-xml <FILE>`.
+
+## Listing Test Cases
+All of the test cases that are found by Greentea can be listed using the command line switch `--list-test-cases`. This will output all of the test binaries that were found, along with their test cases, if they are specified.
+
+An example output of this output is as follows:
+```
+$ mbedgt --list-test-cases
+mbedgt: greentea test automation tool ver. 1.2.0
+mbedgt: using multiple test specifications from current directory!
+        using '.build\tests\K64F\ARM\test_spec.json'
+        using '.build\tests\K64F\GCC_ARM\test_spec.json'
+        using '.build\tests\K64F\IAR\test_spec.json'
+mbedgt: available test cases for test binary '.build/tests/K64F/IAR/features/storage/TESTS/cfstore/flash_set/features-storage-tests-cfstore-flash_set.bin'
+        test case 'FLASH_SET_test_01_start'
+        test case 'FLASH_SET_test_01_end'
+```
+
+## Test Specification with Test Cases
+An example format of `test_spec.json`, that includes the optional field is as follows:
+```json
+{
+  "builds": {
+    "K64F-ARM": {
+      "binary_type": "bootable", 
+      "tests": {
+        "features-storage-tests-cfstore-flash_set": {
+          "binaries": [
+            {
+              "path": ".build/tests/K64F/ARM/features/storage/TESTS/cfstore/flash_set/features-storage-tests-cfstore-flash_set.bin", 
+              "testcases": [
+                "FLASH_SET_test_01_start", 
+                "FLASH_SET_test_01_end"
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+## Testlink XML Report
+An example of the output from using the command line switch `--report-testlink-xml <FILE>` is as follows:
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite failures="0" tests="6" errors="0" time="0.149999856949">
+    <testcase classname="FLASH_SET_test_01_start" host_os="Windows" name="FLASH_SET_test_01_start" time="0.0499999523163"></testcase>
+    <testcase classname="FLASH_SET_test_01_start" host_os="Windows" name="FLASH_SET_test_01_start" time="0.0499999523163"></testcase>
+    <testcase classname="FLASH_SET_test_01_start" host_os="Windows" name="FLASH_SET_test_01_start" time="0.0499999523163"></testcase>
+</testsuite>
 ```
 
 # Using Greentea with new targets

--- a/README.md
+++ b/README.md
@@ -646,7 +646,7 @@ $ mbedgt -V -n mbed-drivers-t*,tests-mbed_drivers-rtc
 ```
 
 # Test Plan Integration
-Greentea has support for using Test Plans to automate the running of tests. Test management systems create a `test_plan.json` file, which is input into Greentea using the `--test-plan <FILE>` command line switch. This tells Greentea which test cases that it should run, which will be checked against the available test cases. It will then choose the correct test binaries, based on the test cases that they contain. If there are test cases specified in the test plan, that Greentea does not know of, then it will report back all of the test cases that it cannot find.
+Greentea has support for using Test Plans to automate the running of tests. Test management systems create a `test_plan.json` file, which is input into Greentea using the `--test-plan <FILE>` command line switch. This tells Greentea which test cases that it should run, which will be checked against the available test cases. It will then choose the correct test binaries, based on the test cases that they contain. If there are test cases specified in the test plan, that Greentea does not know of, then it will report back all of the test cases that it cannot find, but will continue to run the ones it does know of. If it however comes across test cases that have conflicting names (where the test case name is not unique), it will fail and return the conflicting names.
 
 Greentea gets the list of test cases from the `test_spec.json` files that it parses, or has input into it. The test cases are specified in an optional field in the `"binaries"` list, inside `"testcases"`.
 
@@ -655,7 +655,7 @@ The results of the tests can be exported in a JUnit XML format, that is made to 
 ## Listing Test Cases
 All of the test cases that are found by Greentea can be listed using the command line switch `--list-test-cases`. This will output all of the test binaries that were found, along with their test cases, if they are specified.
 
-An example output of this output is as follows:
+An example of this output is as follows:
 ```
 $ mbedgt --list-test-cases
 mbedgt: greentea test automation tool ver. 1.2.0
@@ -666,6 +666,26 @@ mbedgt: using multiple test specifications from current directory!
 mbedgt: available test cases for test binary '.build/tests/K64F/IAR/features/storage/TESTS/cfstore/flash_set/features-storage-tests-cfstore-flash_set.bin'
         test case 'FLASH_SET_test_01_start'
         test case 'FLASH_SET_test_01_end'
+```
+
+## Listing Test Plan
+All of the test cases that are found in the test plan will be output in three different categories Implemented, Not Implemented, and Conflicting using the command line switch `--list-test-plan`. This allows the user to confirm whether the test plan is correct for the current build.
+
+An example of this output is as follows:
+```
+$ mbedgt -V --list-test-plan --test-plan test_plan.json
+mbedgt: greentea test automation tool ver. 1.2.0
+mbedgt: using multiple test specifications from current directory!
+        using '.build\tests\K64F\ARM\test_spec.json'
+        using '.build\tests\K64F\GCC_ARM\test_spec.json'
+        using '.build\tests\K64F\IAR\test_spec.json'
+mbedgt: using Test Plan 'Name'
+mbedgt: implemented test cases
+        test case 'FLASH_SET_test_01_start'
+        test case 'FLASH_SET_test_01_end'
+mbedgt: conflicting test cases (name is not unique)
+        test case 'Repeating Test'
+        test case 'dummy test 2'
 ```
 
 ## Test Specification with Test Cases
@@ -679,12 +699,12 @@ An example format of `test_spec.json`, that includes the optional field is as fo
         "features-storage-tests-cfstore-flash_set": {
           "binaries": [
             {
-              "path": ".build/tests/K64F/ARM/features/storage/TESTS/cfstore/flash_set/features-storage-tests-cfstore-flash_set.bin", 
-              "testcases": [
-                "FLASH_SET_test_01_start", 
-                "FLASH_SET_test_01_end"
-              ]
+              "path": ".build/tests/K64F/ARM/features/storage/TESTS/cfstore/flash_set/features-storage-tests-cfstore-flash_set.bin"
             }
+          ],
+          "testcases": [
+            "FLASH_SET_test_01_start", 
+            "FLASH_SET_test_01_end"
           ]
         }
       }

--- a/mbed_greentea/cmake_handlers.py
+++ b/mbed_greentea/cmake_handlers.py
@@ -123,12 +123,12 @@ def list_binaries_for_builds(test_spec, verbose_footer=False):
         print
         print "Example: execute 'mbedgt -t BUILD_NAME -n TEST_NAME' to run test TEST_NAME for build TARGET_NAME in current test specification"
 
-def list_test_cases_for_binaries(test_spec):
-    """! Parse test spec and list test cases inside the binaries
+def list_test_cases_for_test_names(test_spec):
+    """! Parse test spec and list test cases for each test
     @param test_spec Test specification object
     """
-    test_cases = test_spec.get_test_cases_by_binary()
-    for binary, tc in test_cases.iteritems():
-        gt_logger.gt_log("available test cases for test binary '%s'"% binary)
+    test_cases = test_spec.get_test_cases_by_test_name()
+    for name, tc in test_cases.iteritems():
+        gt_logger.gt_log("available test cases for test '%s'"% name)
         for case in tc:
             gt_logger.gt_log_tab("test case '%s'"% case)

--- a/mbed_greentea/cmake_handlers.py
+++ b/mbed_greentea/cmake_handlers.py
@@ -129,6 +129,6 @@ def list_test_cases_for_binaries(test_spec):
     """
     test_cases = test_spec.get_test_cases_by_binary()
     for binary, tc in test_cases.iteritems():
-        gt_logger.gt_log("available test cases for test '%s'"% binary)
+        gt_logger.gt_log("available test cases for test binary '%s'"% binary)
         for case in tc:
             gt_logger.gt_log_tab("test case '%s'"% case)

--- a/mbed_greentea/cmake_handlers.py
+++ b/mbed_greentea/cmake_handlers.py
@@ -122,3 +122,13 @@ def list_binaries_for_builds(test_spec, verbose_footer=False):
     if verbose_footer:
         print
         print "Example: execute 'mbedgt -t BUILD_NAME -n TEST_NAME' to run test TEST_NAME for build TARGET_NAME in current test specification"
+
+def list_test_cases_for_binaries(test_spec):
+    """! Parse test spec and list test cases inside the binaries
+    @param test_spec Test specification object
+    """
+    test_cases = test_spec.get_test_cases_by_binary()
+    for binary, tc in test_cases.iteritems():
+        gt_logger.gt_log("available test cases for test '%s'"% binary)
+        for case in tc:
+            gt_logger.gt_log_tab("test case '%s'"% case)

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -181,7 +181,6 @@ def create_filtered_test_list(ctest_test_list, test_by_names, skip_test, test_sp
         else:
             list_binaries_for_targets()
 
-    print(filtered_ctest_test_list)
     return filtered_ctest_test_list
 
 def create_testlink_test_list(test_list, available_test_cases, filtered_test_cases, test_spec):

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -926,7 +926,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
 
             test_list = test_build.get_tests()
             if opts.testlink_test_plan:
-                test_case_list = test_build.get_test_cases_by_test_name(binary_type=TestBinary.BIN_TYPE_BOOTABLE)
+                test_case_list = test_build.get_test_cases_test_name(binary_type=TestBinary.BIN_TYPE_BOOTABLE)
                 filtered_ctest_test_list = create_testlink_test_list(test_list, test_case_list, filtered_test_cases, test_spec)
             else:
                 filtered_ctest_test_list = create_filtered_test_list(test_list, opts.test_by_names, opts.skip_test, test_spec=test_spec)

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -193,6 +193,7 @@ def create_test_plan_test_list(test_binary_list, available_test_cases, chosen_te
     """
 
     filtered_test_binary_list = {}
+    chosen_tests_test_cases = {}
     not_implemented_test_cases = []
     if not available_test_cases:
         return {}
@@ -201,14 +202,19 @@ def create_test_plan_test_list(test_binary_list, available_test_cases, chosen_te
     for test_case in chosen_test_cases:
         if test_case in available_test_cases:
             test_binary_name = available_test_cases[test_case]
-            gt_logger.gt_log_tab("test '%s' chosen from test case '%s'"% (
-                gt_logger.gt_bright(test_binary_name),
-                gt_logger.gt_bright(test_case)))
+            if test_binary_name not in chosen_tests_test_cases:
+                chosen_tests_test_cases[test_binary_name] = []
+            chosen_tests_test_cases[test_binary_name].append(test_case)
             if test_binary_name not in filtered_test_binary_list:
                 # Add the TestBinary Object to the filtered test list
                 filtered_test_binary_list[test_binary_name] = test_binary_list[test_binary_name]
         else:
             not_implemented_test_cases.append(test_case)
+    
+    for test_name, test_cases in chosen_tests_test_cases.iteritems():
+        gt_logger.gt_log_tab("test '%s' chosen from test cases"% gt_logger.gt_bright(test_name))
+        for case in test_cases:
+            gt_logger.gt_log_tab("test case '%s'"% case, 2)
 
     if not_implemented_test_cases:
         gt_logger.gt_log_warn("invalid test case names, the following test cases do not exist")
@@ -733,7 +739,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
     if not test_spec:
         return ret
 
-    available_test_cases = test_spec.get_test_cases()
+    available_test_cases = test_spec.get_test_names_by_test_cases()
     filtered_test_cases = []
     # Populate list of the test cases wanted from the test plan
     # All test cases have to have unique names

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -53,6 +53,7 @@ from mbed_greentea.mbed_target_info import get_platform_property
 
 from mbed_greentea.cmake_handlers import list_binaries_for_builds
 from mbed_greentea.cmake_handlers import list_binaries_for_targets
+from mbed_greentea.cmake_handlers import list_test_cases_for_binaries
 
 try:
     import mbed_lstools
@@ -210,14 +211,14 @@ def create_testlink_test_list(test_list, available_test_cases, filtered_test_cas
             invalid_test_cases.append(test_case)
 
     if invalid_test_cases:
-        gt_logger.gt_log_warn("invalid test case names (specified with '--testlink-test-plan' option)")
+        gt_logger.gt_log_warn("invalid test case names, test cases do not exist")
         for test_case in invalid_test_cases:
             test_spec_name = test_spec.test_spec_filename
-            gt_logger.gt_log_warn("test case '%s' not found in '%s' (specified with --test-spec option)"% (gt_logger.gt_bright(test_case),
+            gt_logger.gt_log_warn("test case '%s' not found in '%s' (specified with --test-spec option)"% (
+                gt_logger.gt_bright(test_case),
                 gt_logger.gt_bright(test_spec_name)))
         gt_logger.gt_log_tab("note: test case names are case sensitive")
         gt_logger.gt_log_tab("note: see list of available test cases below")
-        # Print available test suite names (binary names user can use with -n
         list_test_cases_for_binaries(test_spec)
 
     return filtered_test_list

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -211,14 +211,14 @@ def create_test_plan_test_list(test_binary_list, available_test_cases, chosen_te
             not_implemented_test_cases.append(test_case)
 
     if not_implemented_test_cases:
-        gt_logger.gt_log_warn("invalid test case names, test cases do not exist")
+        gt_logger.gt_log_warn("invalid test case names, the following test cases do not exist")
         for test_case in not_implemented_test_cases:
             test_spec_name = test_spec.test_spec_filename
-            gt_logger.gt_log_warn("test case '%s' not found in '%s' (specified with --test-spec option)"% (
+            gt_logger.gt_log_tab("test case '%s' not found in '%s' (specified with --test-spec option)"% (
                 gt_logger.gt_bright(test_case),
                 gt_logger.gt_bright(test_spec_name)))
-        gt_logger.gt_log_tab("note: test case names are case sensitive")
-        gt_logger.gt_log_tab("note: see list of available test cases below")
+        gt_logger.gt_log_warn("note: test case names are case sensitive")
+        gt_logger.gt_log_warn("note: see list of available test cases below")
         list_test_cases_for_test_names(test_spec)
 
     return filtered_test_binary_list
@@ -761,7 +761,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
                 if test_case in all_test_cases:
                     conflicting[build.get_name()].append(test_case)
                 all_test_cases.append(test_case)
-        if conflicting:
+        if all(conflicting.values()):
             for build, test_cases in conflicting.iteritems():
                 gt_logger.gt_log_err("conflicting test cases (name not unique) in build '%s'"% build)
                 for tc in test_cases:

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -53,7 +53,7 @@ from mbed_greentea.mbed_target_info import get_platform_property
 
 from mbed_greentea.cmake_handlers import list_binaries_for_builds
 from mbed_greentea.cmake_handlers import list_binaries_for_targets
-from mbed_greentea.cmake_handlers import list_test_cases_for_binaries
+from mbed_greentea.cmake_handlers import list_test_cases_for_test_names
 
 try:
     import mbed_lstools
@@ -219,7 +219,7 @@ def create_test_plan_test_list(test_binary_list, available_test_cases, chosen_te
                 gt_logger.gt_bright(test_spec_name)))
         gt_logger.gt_log_tab("note: test case names are case sensitive")
         gt_logger.gt_log_tab("note: see list of available test cases below")
-        list_test_cases_for_binaries(test_spec)
+        list_test_cases_for_test_names(test_spec)
 
     return filtered_test_binary_list
 
@@ -926,7 +926,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
 
             test_list = test_build.get_tests()
             if opts.test_plan:
-                test_case_list = test_build.get_test_cases_test_name(binary_type=TestBinary.BIN_TYPE_BOOTABLE)
+                test_case_list = test_build.get_test_cases_test_name()
                 filtered_ctest_test_list = create_test_plan_test_list(test_list, test_case_list, filtered_test_cases, test_spec)
             else:
                 filtered_ctest_test_list = create_filtered_test_list(test_list, opts.test_by_names, opts.skip_test, test_spec=test_spec)

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -40,6 +40,7 @@ from mbed_greentea.mbed_report_api import exporter_testcase_text
 from mbed_greentea.mbed_report_api import exporter_json
 from mbed_greentea.mbed_report_api import exporter_testcase_junit
 from mbed_greentea.mbed_report_api import exporter_html
+from mbed_greentea.mbed_report_api import exporter_testlink_xml
 from mbed_greentea.mbed_greentea_log import gt_logger
 from mbed_greentea.mbed_greentea_dlm import GREENTEA_KETTLE_PATH
 from mbed_greentea.mbed_greentea_dlm import greentea_get_app_sem
@@ -310,6 +311,10 @@ def main():
     parser.add_option('', '--report-json',
                     dest='report_json_file_name',
                     help='You can log test suite results to JSON formatted file')
+
+    parser.add_option('', '--report-testlink-xml',
+                    dest='report_testlink_xml_file_name',
+                    help='You can log test suite results to a Testlink XML formatted file')
 
     parser.add_option('', '--report-html',
                     dest='report_html_file_name',
@@ -1006,6 +1011,12 @@ def main_cli(opts, args, gt_instance_uuid=None):
             # Generate a HTML page displaying all of the results
             html_report = exporter_html(test_report)
             dump_report_to_text_file(opts.report_html_file_name, html_report)
+
+        if opts.report_testlink_xml_file_name:
+            gt_logger.gt_log("exporting to Testlink XML file '%s'..."% gt_logger.gt_bright(opts.report_testlink_xml_file_name))
+            # Generate a Testlink XML with all of the results
+            testlink_xml_report = exporter_testlink_xml(test_report)
+            dump_report_to_text_file(opts.report_testlink_xml_file_name, testlink_xml_report)
 
         # Final summary
         if test_report:

--- a/mbed_greentea/mbed_report_api.py
+++ b/mbed_greentea/mbed_report_api.py
@@ -225,12 +225,13 @@ def exporter_testlink_xml(test_result_ext, filtered_test_cases=None, test_suite_
     @return String containing Testlink XML formatted test result output
     """
 
-    from platform import system
+    #from platform import system
     from StringIO import StringIO
     from xml.sax.saxutils import XMLGenerator
     from xml.sax.xmlreader import AttributesImpl
 
-    host_os = system()
+    # Will add Host OS attribute in the future
+    #host_os = system()
     output = StringIO()
     generator = XMLGenerator(output, 'UTF-8')
     generator.startDocument()
@@ -251,7 +252,8 @@ def exporter_testlink_xml(test_result_ext, filtered_test_cases=None, test_suite_
         'errors': str(errors),
         'failures': str(failures),
         'tests': str(tests),
-        'time': str(time)}))
+        'time': str(time)
+    }))
 
     for target_toolcahin, testsuites in test_result_ext.iteritems():
         for testsuite_name, testsuite in testsuites.iteritems():
@@ -260,9 +262,18 @@ def exporter_testlink_xml(test_result_ext, filtered_test_cases=None, test_suite_
                     output.write("\n\t".expandtabs(4))
                     generator.startElement('testcase', AttributesImpl({
                         'classname': testcase_name,
-                        'host_os': host_os,
                         'name': testcase_name,
-                        'time': str(testcase['duration'])}))
+                        'time': str(testcase['duration'])
+                    }))
+                    if testcase['result'] != 0:
+                        element_name = 'error' if testcase['result'] < 0 else 'failure'
+                        type = 'skipped' if testcase['result'] == -8192 else None
+                        attributes = {}
+                        if type:
+                            attributes['type'] = type
+                        output.write("\n\t\t".expandtabs(4))
+                        generator.startElement(element_name, AttributesImpl(attributes))
+                        output.write("\n\t".expandtabs(4))
                     generator.endElement('testcase')
     output.write("\n")
     generator.endElement('testsuite')

--- a/mbed_greentea/mbed_report_api.py
+++ b/mbed_greentea/mbed_report_api.py
@@ -244,13 +244,21 @@ def exporter_testlink_xml(test_result_ext, test_suite_properties=None):
                 if testcase['result'] < 0:
                     errors += 1
                 failures += testcase['failed']
-    generator.startElement('testsuite', AttributesImpl({'errors': str(errors), 'failures': str(failures), 'tests': str(tests), 'time': str(time)}))
+    generator.startElement('testsuite', AttributesImpl({
+        'errors': str(errors),
+        'failures': str(failures),
+        'tests': str(tests),
+        'time': str(time)}))
 
     for target_toolcahin, testsuites in test_result_ext.iteritems():
         for testsuite_name, testsuite in testsuites.iteritems():
             for testcase_name, testcase in testsuite['testcase_result'].iteritems():
                 output.write("\n\t".expandtabs(4))
-                generator.startElement('testcase', AttributesImpl({'classname': testcase_name, 'host_os': host_os, 'name': testcase_name, 'time': str(testcase['duration'])}))
+                generator.startElement('testcase', AttributesImpl({
+                    'classname': testcase_name,
+                    'host_os': host_os,
+                    'name': testcase_name,
+                    'time': str(testcase['duration'])}))
                 generator.endElement('testcase')
     output.write("\n")
     generator.endElement('testsuite')

--- a/mbed_greentea/mbed_report_api.py
+++ b/mbed_greentea/mbed_report_api.py
@@ -273,6 +273,7 @@ def exporter_testlink_xml(test_result_ext, filtered_test_cases=None, test_suite_
                             attributes['type'] = type
                         output.write("\n\t\t".expandtabs(4))
                         generator.startElement(element_name, AttributesImpl(attributes))
+                        generator.endElement(element_name)
                         output.write("\n\t".expandtabs(4))
                     generator.endElement('testcase')
     output.write("\n")

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -578,37 +578,29 @@ def get_test_spec(opts):
         # Test specification from command line (--test-spec) or default test_spec.json will be used
         gt_logger.gt_log("using '%s' from current directory!"% test_spec_file_name)
         test_spec = TestSpec(test_spec_file_name)
-        if opts.list_binaries:
-            list_binaries_for_builds(test_spec)
-            return None, 0
-        elif opts.list_test_cases:
-            list_test_cases_for_test_names(test_spec)
-            return None, 0
     elif test_spec_file_name_list:
         # Merge multiple test specs into one and keep calm
         gt_logger.gt_log("using multiple test specifications from current directory!")
         test_spec = merge_multiple_test_specifications_from_file_list(test_spec_file_name_list)
-        if opts.list_binaries:
-            list_binaries_for_builds(test_spec)
-            return None, 0
-        elif opts.list_test_cases:
-            list_test_cases_for_test_names(test_spec)
-            return None, 0
     elif os.path.exists('module.json'):
         # If inside yotta module load module data and generate test spec
         gt_logger.gt_log("using 'module.json' from current directory!")
+        test_spec = get_test_spec_from_yt_module(opts)
         if opts.list_binaries:
             # List available test binaries (names, no extension)
             list_binaries_for_targets()
             return None, 0
-        elif opts.list_test_cases:
-            list_test_cases_for_test_names(test_spec)
-            return None, 0
-        else:
-            test_spec = get_test_spec_from_yt_module(opts)
     else:
         gt_logger.gt_log_err("greentea should be run inside a Yotta module or --test-spec switch should be used")
         return None, -1
+
+    if opts.list_binaries:
+        list_binaries_for_builds(test_spec)
+        return None, 0
+    elif opts.list_test_cases:
+        list_test_cases_for_test_names(test_spec)
+        return None, 0
+
     return test_spec, 0
 
 def get_test_build_properties(test_spec, test_build_name):

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -32,7 +32,7 @@ from mbed_greentea.mbed_coverage_api import coverage_pack_hex_payload
 
 from mbed_greentea.cmake_handlers import list_binaries_for_builds
 from mbed_greentea.cmake_handlers import list_binaries_for_targets
-from mbed_greentea.cmake_handlers import list_test_cases_for_binaries
+from mbed_greentea.cmake_handlers import list_test_cases_for_test_names
 
 
 # Return codes for test script
@@ -582,7 +582,7 @@ def get_test_spec(opts):
             list_binaries_for_builds(test_spec)
             return None, 0
         elif opts.list_test_cases:
-            list_test_cases_for_binaries(test_spec)
+            list_test_cases_for_test_names(test_spec)
             return None, 0
     elif test_spec_file_name_list:
         # Merge multiple test specs into one and keep calm
@@ -592,7 +592,7 @@ def get_test_spec(opts):
             list_binaries_for_builds(test_spec)
             return None, 0
         elif opts.list_test_cases:
-            list_test_cases_for_binaries(test_spec)
+            list_test_cases_for_test_names(test_spec)
             return None, 0
     elif os.path.exists('module.json'):
         # If inside yotta module load module data and generate test spec
@@ -602,7 +602,7 @@ def get_test_spec(opts):
             list_binaries_for_targets()
             return None, 0
         elif opts.list_test_cases:
-            list_test_cases_for_binaries(test_spec)
+            list_test_cases_for_test_names(test_spec)
             return None, 0
         else:
             test_spec = get_test_spec_from_yt_module(opts)

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -571,7 +571,7 @@ def get_test_spec(opts):
         test_spec_file_name_list = get_all_test_specs_from_build_dir('.build')
     elif os.path.exists(os.path.join('mbed-os', '.build')):
         # Checking mbed-os/.build directory for test specifications
-        test_spec_file_name_list = get_all_test_specs_from_build_dir(os.path.join(['mbed-os', '.build']))
+        test_spec_file_name_list = get_all_test_specs_from_build_dir(os.path.join('mbed-os', '.build'))
 
     # Actual load and processing of test specification from sources
     if test_spec_file_name:

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -32,6 +32,7 @@ from mbed_greentea.mbed_coverage_api import coverage_pack_hex_payload
 
 from mbed_greentea.cmake_handlers import list_binaries_for_builds
 from mbed_greentea.cmake_handlers import list_binaries_for_targets
+from mbed_greentea.cmake_handlers import list_test_cases_for_binaries
 
 
 # Return codes for test script
@@ -580,6 +581,9 @@ def get_test_spec(opts):
         if opts.list_binaries:
             list_binaries_for_builds(test_spec)
             return None, 0
+        elif opts.list_test_cases:
+            list_test_cases_for_binaries(test_spec)
+            return None, 0
     elif test_spec_file_name_list:
         # Merge multiple test specs into one and keep calm
         gt_logger.gt_log("using multiple test specifications from current directory!")
@@ -587,12 +591,18 @@ def get_test_spec(opts):
         if opts.list_binaries:
             list_binaries_for_builds(test_spec)
             return None, 0
+        elif opts.list_test_cases:
+            list_test_cases_for_binaries(test_spec)
+            return None, 0
     elif os.path.exists('module.json'):
         # If inside yotta module load module data and generate test spec
         gt_logger.gt_log("using 'module.json' from current directory!")
         if opts.list_binaries:
             # List available test binaries (names, no extension)
             list_binaries_for_targets()
+            return None, 0
+        elif opts.list_test_cases:
+            list_test_cases_for_binaries(test_spec)
             return None, 0
         else:
             test_spec = get_test_spec_from_yt_module(opts)

--- a/mbed_greentea/tests_spec.py
+++ b/mbed_greentea/tests_spec.py
@@ -228,7 +228,7 @@ class TestBuild:
         """
         return self.__tests
 
-    def get_test_cases_by_test_name(self, binary_type=TestBinary.BIN_TYPE_DEFAULT):
+    def get_test_cases_test_name(self, binary_type=TestBinary.BIN_TYPE_DEFAULT):
         """
         Gives test cases dict keyed by test case.
 
@@ -303,7 +303,7 @@ class TestSpec:
         Load test spec directly from file
 
         :param test_spec_filename: Name of JSON file with TestSpec to load
-        :return: Treu if load was successful
+        :return: True if load was successful
         """
         try:
             with open(test_spec_filename, "r") as f:
@@ -380,7 +380,7 @@ class TestSpec:
                 test_cases = test.get_binary().get_test_cases()
                 if test_cases:
                     result.extend(test_cases)
-        return result
+        return set(result)
 
     def get_test_cases_by_binary(self):
         """

--- a/mbed_greentea/tests_spec.py
+++ b/mbed_greentea/tests_spec.py
@@ -379,6 +379,31 @@ class TestSpec:
                     result.extend(test_cases)
         return set(result)
 
+    def get_test_names_by_test_cases(self):
+        """
+        Gives test cases test names.
+
+        :return: A dictionary of test cases against it's test name/binary
+        """
+        invalid_names = []
+        result = {}
+        for test_build in self.__target_test_spec.values():
+            for test_name, test in test_build.get_tests().iteritems():
+                for test_case in test.get_test_cases():
+                    # Skip test cases with conflicts
+                    if test_case not in invalid_names:
+                        if test_case in result:
+                            if result[test_case] is not test:
+                                if test_case not in invalid_names:
+                                    invalid_names.append(test_case)
+                        else:
+                            result[test_case] = test_name
+
+        if invalid_names:
+            for value in invalid_names:
+                print "TestBuild::get_test_cases_tests - Conflicting test case '%s' - Skipped"% value
+        return result
+
     def get_test_cases_by_test_name(self):
         """
         Gives test cases.

--- a/mbed_greentea/tests_spec.py
+++ b/mbed_greentea/tests_spec.py
@@ -214,6 +214,17 @@ class TestBuild:
         """
         return self.__tests
 
+    def get_test_cases(self):
+        """
+        Gives all of the test cases for the build.
+
+        :return: Array of all of the test cases
+        """
+        test_cases = []
+        for test in self.__tests.values():
+            test_cases.extend(test.get_test_cases())
+        return test_cases
+
     def get_test_cases_test_name(self):
         """
         Gives test cases dict keyed by test case.

--- a/mbed_greentea/tests_spec.py
+++ b/mbed_greentea/tests_spec.py
@@ -37,7 +37,7 @@ class TestBinary:
     BIN_TYPE_DEFAULT = BIN_TYPE_BOOTABLE
     SUPPORTED_BIN_TYPES = [BIN_TYPE_BOOTABLE]
 
-    def __init__(self, path, binary_type, testcases=None):
+    def __init__(self, path, binary_type, testcases=[]):
         """
         ctor.
 
@@ -235,6 +235,7 @@ class TestBuild:
         :param binary_type: Type of the binary
         :return: Dict of test case against test name
         """
+        conflict_string = "TestBuild::get_test_cases_tests - Conflicting test case '%s' matches '%s' and '%s'"
         invalid_names = {}
         result = {}
         for name, test in self.__tests.iteritems():
@@ -242,7 +243,7 @@ class TestBuild:
                 if test_case in result:
                     if result[test_case] is not name:
                         if test_case not in invalid_names:
-                            invalid_names[test_case] = "TestBuild::get_test_cases_tests - Conflicting test case '%s' matches '%s' and '%s'"% (
+                            invalid_names[test_case] = conflict_string% (
                                 test_case,
                                 result[test_case],
                                 name)
@@ -250,7 +251,7 @@ class TestBuild:
                     result[test_case] = name
         if invalid_names:
             for value in invalid_names.values():
-                print(value)
+                print value
             return {}
         else:
             return result
@@ -367,7 +368,7 @@ class TestSpec:
         """
         return self.__target_test_spec.get(build_name, None)
 
-    def get_test_cases(self, by_binary=False):
+    def get_test_cases(self):
         """
         Gives test cases.
 
@@ -385,7 +386,6 @@ class TestSpec:
         """
         Gives test cases.
 
-        :param by_binary: List the binaries against its test cases
         :return: A dictionary of binary against its test cases
         """
         result = {}

--- a/test/mbed_gt_tests_spec.py
+++ b/test/mbed_gt_tests_spec.py
@@ -78,32 +78,32 @@ test_case_test_spec = {
                     "binaries": [
                         {
                             "binary_type": "bootable",
-                            "path": ".build/tests/K64F/ARM/TESTS/mbed_drivers/generic_tests/tests-mbed_drivers-generic_tests.bin", 
-                            "testcases": [
-                                "Blinky", 
-                                "C++ stack", 
-                                "C++ heap", 
-                                "Basic"
-                            ]
+                            "path": ".build/tests/K64F/ARM/TESTS/mbed_drivers/generic_tests/tests-mbed_drivers-generic_tests.bin"
                         }
+                    ],
+                    "testcases": [
+                        "Blinky", 
+                        "C++ stack", 
+                        "C++ heap", 
+                        "Basic"
                     ]
                 },
                 "tests-mbed_drivers-c_strings": {
                     "binaries": [
                         {
                             "binary_type": "bootable",
-                            "path": ".build/tests/K64F/ARM/TESTS/mbed_drivers/c_strings/tests-mbed_drivers-c_strings.bin", 
-                            "testcases": [
-                                "C strings: strpbrk", 
-                                "C strings: %g %g float formatting", 
-                                "C strings: %f %f float formatting", 
-                                "C strings: %u %d integer formatting", 
-                                "C strings: strtok", 
-                                "C strings: %i %d integer formatting", 
-                                "C strings: %e %E float formatting", 
-                                "C strings: %x %E integer formatting"
-                            ]
+                            "path": ".build/tests/K64F/ARM/TESTS/mbed_drivers/c_strings/tests-mbed_drivers-c_strings.bin"
                         }
+                    ],
+                    "testcases": [
+                        "C strings: strpbrk", 
+                        "C strings: %g %g float formatting", 
+                        "C strings: %f %f float formatting", 
+                        "C strings: %u %d integer formatting", 
+                        "C strings: strtok", 
+                        "C strings: %i %d integer formatting", 
+                        "C strings: %e %E float formatting", 
+                        "C strings: %x %E integer formatting"
                     ]
                 }
             }
@@ -261,17 +261,15 @@ class TestsSpecFunctionality(unittest.TestCase):
         self.assertIn('C strings: %g %g float formatting', test_cases)
         self.assertIn('C++ stack', test_cases)
 
-    def test_get_test_cases_by_binary(self):
+    def test_get_test_cases_by_name(self):
         self.test_spec = TestSpec()
         self.test_spec.parse(self.tc_ts)
-        test_cases = self.test_spec.get_test_cases_by_binary()
+        test_cases = self.test_spec.get_test_cases_by_test_name()
 
         self.assertIs(type(test_cases), dict)
-        self.assertEqual(len(test_cases), 3)
-        self.assertIn(".build/tests/K64F/ARM/TESTS/mbed_drivers/generic_tests/tests-mbed_drivers-generic_tests.bin", test_cases)
-        self.assertIn(".build/tests/K64F/ARM/TESTS/mbed_drivers/c_strings/tests-mbed_drivers-c_strings.bin", test_cases)
-        self.assertIn(".build/tests/K64F/GCC_ARM/TESTS/mbed_drivers/generic_tests/tests-mbed_drivers-generic_tests.bin", test_cases)
-        self.assertEqual(len(test_cases[".build/tests/K64F/GCC_ARM/TESTS/mbed_drivers/generic_tests/tests-mbed_drivers-generic_tests.bin"]), 4)
+        self.assertEqual(len(test_cases), 2)
+        self.assertIn("tests-mbed_drivers-c_strings", test_cases)
+        self.assertEqual(len(test_cases["tests-mbed_drivers-c_strings"]), 8)
 
     def test_get_test_cases_by_test_name(self):
         self.test_spec = TestSpec()

--- a/test/mbed_gt_tests_spec.py
+++ b/test/mbed_gt_tests_spec.py
@@ -17,7 +17,7 @@ limitations under the License.
 """
 
 import unittest
-from mbed_greentea.tests_spec import TestSpec, TestBinary
+from mbed_greentea.tests_spec import TestSpec
 
 simple_test_spec = {
     "builds": {
@@ -66,11 +66,91 @@ simple_test_spec = {
     }
 }
 
+test_case_test_spec = {
+    "builds": {
+        "K64F-ARM": {
+            "platform": "K64F",
+            "toolchain": "ARM",
+            "base_path": "./.build/K64F/ARM",
+            "baud_rate": 115200,
+            "tests": {
+                "tests-mbed_drivers-generic_tests": {
+                    "binaries": [
+                        {
+                            "binary_type": "bootable",
+                            "path": ".build/tests/K64F/ARM/TESTS/mbed_drivers/generic_tests/tests-mbed_drivers-generic_tests.bin", 
+                            "testcases": [
+                                "Blinky", 
+                                "C++ stack", 
+                                "C++ heap", 
+                                "Basic"
+                            ]
+                        }
+                    ]
+                },
+                "tests-mbed_drivers-c_strings": {
+                    "binaries": [
+                        {
+                            "binary_type": "bootable",
+                            "path": ".build/tests/K64F/ARM/TESTS/mbed_drivers/c_strings/tests-mbed_drivers-c_strings.bin", 
+                            "testcases": [
+                                "C strings: strpbrk", 
+                                "C strings: %g %g float formatting", 
+                                "C strings: %f %f float formatting", 
+                                "C strings: %u %d integer formatting", 
+                                "C strings: strtok", 
+                                "C strings: %i %d integer formatting", 
+                                "C strings: %e %E float formatting", 
+                                "C strings: %x %E integer formatting"
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "K64F-GCC": {
+            "platform": "K64F",
+            "toolchain": "GCC_ARM",
+            "base_path": "./.build/K64F/GCC_ARM",
+            "baud_rate": 9600,
+            "tests": {
+                "tests-mbed_drivers-generic_tests": {
+                    "binaries": [
+                        {
+                            "binary_type": "bootable",
+                            "path": ".build/tests/K64F/GCC_ARM/TESTS/mbed_drivers/generic_tests/tests-mbed_drivers-generic_tests.bin", 
+                            "testcases": [
+                                "Blinky", 
+                                "C++ stack", 
+                                "C++ heap", 
+                                "Basic"
+                            ]
+                        }
+                    ]
+                },
+                "tests-mbed_drivers-c_strings": {
+                    "binaries": [
+                        {
+                            "binary_type": "bootable",
+                            "path": ".build/tests/K64F/ARM/TESTS/mbed_drivers/c_strings/tests-mbed_drivers-c_strings.bin", 
+                            "testcases": [
+                                "Blinky"
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+
+    }
+}
+
 
 class TestsSpecFunctionality(unittest.TestCase):
 
     def setUp(self):
-        self.ts_2_builds = simple_test_spec
+        self.test_specs = [simple_test_spec, test_case_test_spec]
+        self.tc_ts = test_case_test_spec
 
     def tearDown(self):
         pass
@@ -80,89 +160,144 @@ class TestsSpecFunctionality(unittest.TestCase):
         self.assertNotEqual(True, False)
 
     def test_get_test_builds(self):
-        self.test_spec = TestSpec()
-        self.test_spec.parse(self.ts_2_builds)
-        test_builds = self.test_spec.get_test_builds()
+        # Test compatibility with old and new format
+        for test_spec in self.test_specs:
+            self.test_spec = TestSpec()
+            self.test_spec.parse(test_spec)
+            test_builds = self.test_spec.get_test_builds()
 
-        self.assertIs(type(test_builds), list)
-        self.assertEqual(len(test_builds), 2)
+            self.assertIs(type(test_builds), list)
+            self.assertEqual(len(test_builds), 2)
 
     def test_get_test_builds_names(self):
-        self.test_spec = TestSpec()
-        self.test_spec.parse(self.ts_2_builds)
-        test_builds = self.test_spec.get_test_builds()
-        test_builds_names = [x.get_name() for x in self.test_spec.get_test_builds()]
+        for test_spec in self.test_specs:
+            self.test_spec = TestSpec()
+            self.test_spec.parse(test_spec)
+            test_builds = self.test_spec.get_test_builds()
+            test_builds_names = [x.get_name() for x in self.test_spec.get_test_builds()]
 
-        self.assertEqual(len(test_builds_names), 2)
-        self.assertIs(type(test_builds_names), list)
+            self.assertEqual(len(test_builds_names), 2)
+            self.assertIs(type(test_builds_names), list)
 
-        self.assertIn('K64F-ARM', test_builds_names)
-        self.assertIn('K64F-GCC', test_builds_names)
+            self.assertIn('K64F-ARM', test_builds_names)
+            self.assertIn('K64F-GCC', test_builds_names)
 
     def test_get_test_build(self):
-        self.test_spec = TestSpec()
-        self.test_spec.parse(self.ts_2_builds)
-        test_builds = self.test_spec.get_test_builds()
-        test_builds_names = [x.get_name() for x in self.test_spec.get_test_builds()]
+        for test_spec in self.test_specs:
+            self.test_spec = TestSpec()
+            self.test_spec.parse(test_spec)
+            test_builds = self.test_spec.get_test_builds()
+            test_builds_names = [x.get_name() for x in self.test_spec.get_test_builds()]
 
-        self.assertEqual(len(test_builds_names), 2)
-        self.assertIs(type(test_builds_names), list)
+            self.assertEqual(len(test_builds_names), 2)
+            self.assertIs(type(test_builds_names), list)
 
-        self.assertNotEqual(None, self.test_spec.get_test_build('K64F-ARM'))
-        self.assertNotEqual(None, self.test_spec.get_test_build('K64F-GCC'))
+            self.assertNotEqual(None, self.test_spec.get_test_build('K64F-ARM'))
+            self.assertNotEqual(None, self.test_spec.get_test_build('K64F-GCC'))
 
     def test_get_build_properties(self):
-        self.test_spec = TestSpec()
-        self.test_spec.parse(self.ts_2_builds)
-        test_builds = self.test_spec.get_test_builds()
-        test_builds_names = [x.get_name() for x in self.test_spec.get_test_builds()]
+        for test_spec in self.test_specs:
+            self.test_spec = TestSpec()
+            self.test_spec.parse(test_spec)
+            test_builds = self.test_spec.get_test_builds()
+            test_builds_names = [x.get_name() for x in self.test_spec.get_test_builds()]
 
-        self.assertEqual(len(test_builds_names), 2)
-        self.assertIs(type(test_builds_names), list)
+            self.assertEqual(len(test_builds_names), 2)
+            self.assertIs(type(test_builds_names), list)
 
-        k64f_arm = self.test_spec.get_test_build('K64F-ARM')
-        k64f_gcc = self.test_spec.get_test_build('K64F-GCC')
+            k64f_arm = self.test_spec.get_test_build('K64F-ARM')
+            k64f_gcc = self.test_spec.get_test_build('K64F-GCC')
 
-        self.assertNotEqual(None, k64f_arm)
-        self.assertNotEqual(None, k64f_gcc)
+            self.assertNotEqual(None, k64f_arm)
+            self.assertNotEqual(None, k64f_gcc)
 
-        self.assertEqual('K64F', k64f_arm.get_platform())
-        self.assertEqual('ARM', k64f_arm.get_toolchain())
-        self.assertEqual(115200, k64f_arm.get_baudrate())
+            self.assertEqual('K64F', k64f_arm.get_platform())
+            self.assertEqual('ARM', k64f_arm.get_toolchain())
+            self.assertEqual(115200, k64f_arm.get_baudrate())
 
-        self.assertEqual('K64F', k64f_gcc.get_platform())
-        self.assertEqual('GCC_ARM', k64f_gcc.get_toolchain())
-        self.assertEqual(9600, k64f_gcc.get_baudrate())
+            self.assertEqual('K64F', k64f_gcc.get_platform())
+            self.assertEqual('GCC_ARM', k64f_gcc.get_toolchain())
+            self.assertEqual(9600, k64f_gcc.get_baudrate())
 
     def test_get_test_builds_properties(self):
-        self.test_spec = TestSpec()
-        self.test_spec.parse(self.ts_2_builds)
-        test_builds = self.test_spec.get_test_builds()
-        test_builds_names = [x.get_name() for x in self.test_spec.get_test_builds()]
+        for test_spec in self.test_specs:
+            self.test_spec = TestSpec()
+            self.test_spec.parse(test_spec)
+            test_builds = self.test_spec.get_test_builds()
+            test_builds_names = [x.get_name() for x in self.test_spec.get_test_builds()]
 
-        self.assertIn('K64F-ARM', test_builds_names)
-        self.assertIn('K64F-GCC', test_builds_names)
+            self.assertIn('K64F-ARM', test_builds_names)
+            self.assertIn('K64F-GCC', test_builds_names)
 
     def test_get_test_builds_names_filter_by_names(self):
+        for test_spec in self.test_specs:
+            self.test_spec = TestSpec()
+            self.test_spec.parse(test_spec)
+
+            filter_by_names = ['K64F-ARM']
+            test_builds = self.test_spec.get_test_builds(filter_by_names=filter_by_names)
+            test_builds_names = [x.get_name() for x in test_builds]
+            self.assertEqual(len(test_builds_names), 1)
+            self.assertIn('K64F-ARM', test_builds_names)
+
+            filter_by_names = ['K64F-GCC']
+            test_builds = self.test_spec.get_test_builds(filter_by_names=filter_by_names)
+            test_builds_names = [x.get_name() for x in test_builds]
+            self.assertEqual(len(test_builds_names), 1)
+            self.assertIn('K64F-GCC', test_builds_names)
+
+            filter_by_names = ['SOME-PLATFORM-NAME']
+            test_builds = self.test_spec.get_test_builds(filter_by_names=filter_by_names)
+            test_builds_names = [x.get_name() for x in test_builds]
+            self.assertEqual(len(test_builds_names), 0)
+
+    def test_get_test_cases(self):
         self.test_spec = TestSpec()
-        self.test_spec.parse(self.ts_2_builds)
+        self.test_spec.parse(self.tc_ts)
+        test_cases = self.test_spec.get_test_cases()
 
-        filter_by_names = ['K64F-ARM']
-        test_builds = self.test_spec.get_test_builds(filter_by_names=filter_by_names)
-        test_builds_names = [x.get_name() for x in test_builds]
-        self.assertEqual(len(test_builds_names), 1)
-        self.assertIn('K64F-ARM', test_builds_names)
+        self.assertIs(type(test_cases), set)
+        self.assertEqual(len(test_cases), 12)
+        self.assertIn('C strings: %g %g float formatting', test_cases)
+        self.assertIn('C++ stack', test_cases)
 
-        filter_by_names = ['K64F-GCC']
-        test_builds = self.test_spec.get_test_builds(filter_by_names=filter_by_names)
-        test_builds_names = [x.get_name() for x in test_builds]
-        self.assertEqual(len(test_builds_names), 1)
-        self.assertIn('K64F-GCC', test_builds_names)
+    def test_get_test_cases_by_binary(self):
+        self.test_spec = TestSpec()
+        self.test_spec.parse(self.tc_ts)
+        test_cases = self.test_spec.get_test_cases_by_binary()
 
-        filter_by_names = ['SOME-PLATFORM-NAME']
-        test_builds = self.test_spec.get_test_builds(filter_by_names=filter_by_names)
-        test_builds_names = [x.get_name() for x in test_builds]
-        self.assertEqual(len(test_builds_names), 0)
+        self.assertIs(type(test_cases), dict)
+        self.assertEqual(len(test_cases), 3)
+        self.assertIn(".build/tests/K64F/ARM/TESTS/mbed_drivers/generic_tests/tests-mbed_drivers-generic_tests.bin", test_cases)
+        self.assertIn(".build/tests/K64F/ARM/TESTS/mbed_drivers/c_strings/tests-mbed_drivers-c_strings.bin", test_cases)
+        self.assertIn(".build/tests/K64F/GCC_ARM/TESTS/mbed_drivers/generic_tests/tests-mbed_drivers-generic_tests.bin", test_cases)
+        self.assertEqual(len(test_cases[".build/tests/K64F/GCC_ARM/TESTS/mbed_drivers/generic_tests/tests-mbed_drivers-generic_tests.bin"]), 4)
+
+    def test_get_test_cases_by_test_name(self):
+        self.test_spec = TestSpec()
+        self.test_spec.parse(self.tc_ts)
+        test_builds = self.test_spec.get_test_builds(filter_by_names=['K64F-ARM'])
+        
+        self.assertEqual(len(test_builds), 1)
+
+        test_case_test_names = test_builds[0].get_test_cases_test_name()
+
+        self.assertEqual(len(test_case_test_names), 12)
+        self.assertIn('Blinky', test_case_test_names)
+        self.assertEqual('tests-mbed_drivers-generic_tests', test_case_test_names['Blinky'])
+        self.assertIn('C strings: %g %g float formatting', test_case_test_names)
+        self.assertEqual('tests-mbed_drivers-c_strings', test_case_test_names['C strings: %g %g float formatting'])
+
+    def test_get_test_cases_by_test_name_conflict(self):
+        self.test_spec = TestSpec()
+        self.test_spec.parse(self.tc_ts)
+        test_builds = self.test_spec.get_test_builds(filter_by_names=['K64F-GCC'])
+        
+        self.assertEqual(len(test_builds), 1)
+
+        test_case_test_names = test_builds[0].get_test_cases_test_name()
+
+        self.assertEqual(len(test_case_test_names), 0)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# Changes
* Added support for new test_spec.json format
  * Will extract the test cases for each binary
  * Backwards compatibility so nothing changes if the test cases are not specified
* Added support for the filtering of tests by test case
* Added support for the parsing of a Testlink test plan with command line switch `--testlink-test-plan <FILE>`
  * Chooses the tests to run based on the test cases specified
* Added command line switch to output all of the test casesfound, for all of the builds `--list-test-cases`
* Added command line switch to ouput all of the test cases from the test plan, showing the implemented, not implemented, and conflicting, using `--list-test-plan`
* Added exporter to produce report for Testlink in XML format
* Added command line switch `--report-testlink-xml <FILE>` to output the Testlink XML format to a file
* Updated README to include information on Testlink Integration

# Test Spec Format
Example of the current format:
```
{
  "builds": {
    "K64F-ARM": {
      "binary_type": "bootable", 
      "tests": {
        "features-storage-tests-cfstore-flash_set": {
          "binaries": [
            {
              "path": ".build/tests/K64F/ARM/features/storage/TESTS/cfstore/flash_set/features-storage-tests-cfstore-flash_set.bin"
            }
          ]
        . . .
```
Example of the new format (Note the addition of the test cases):
```
{
  "builds": {
    "K64F-ARM": {
      "binary_type": "bootable", 
      "tests": {
        "features-storage-tests-cfstore-flash_set": {
          "binaries": [
            {
              "path": ".build/tests/K64F/ARM/features/storage/TESTS/cfstore/flash_set/features-storage-tests-cfstore-flash_set.bin"
            }
          ],
        "testcases": [
          "FLASH_SET_test_01_start", 
          "FLASH_SET_test_01_end"
        ]
        . . .
```

# Test Plan Format
Example of a `test_plan.json`:
```
{
    "testplan": {
        "name": "Test Plan Name",
        "testcases": [
            {"name": "Test Case Name", "properties": { Reserved for future use }},
            . . . 
```

# List Test Cases
Example output of `--list-test-cases:
```
mbedgt: available test cases for test '.build/tests/K64F/IAR/features/storage/TESTS/cfstore/open/features-storage-tests-cfstore-open.bin'
        test case 'OPEN_test_05_end'
        test case 'OPEN_test_03_start'
        test case 'OPEN_test_02_end'
        test case 'OPEN_test_04_end'
        test case 'OPEN_test_05_start'
        test case 'OPEN_test_06_end'
        test case 'OPEN_test_06_start'
        test case 'OPEN_test_01_start'
        test case 'OPEN_test_04_start'
        test case 'OPEN_test_00'
        test case 'OPEN_test_02_start'
        test case 'OPEN_test_03_end'
        test case 'OPEN_test_01_end'
        test case 'OPEN_test_07_start'
        test case 'OPEN_test_07_end'
mbedgt: available test cases for test '.build/tests/K64F/ARM/frameworks/utest/TESTS/unit_tests/case_control_async/frameworks-utest-tests-unit_tests-case_control_async.bin'
        test case 'Control: Timeout (Failure)'
        test case 'Control: CaseNext'
        test case 'Control: NoTimeout'
        test case 'Control: Await'
        test case 'Control: Timeout (Success)'
        test case 'Control: RepeatHandlerOnTimeout'
        test case 'Control: RepeatAllOnTimeout'
```

# List Test Plan
An example output of `--list-test-plan`:
```
$ mbedgt -V --list-test-plan --test-plan test_plan.json
mbedgt: greentea test automation tool ver. 1.2.0
mbedgt: using multiple test specifications from current directory!
        using '.build\tests\K64F\ARM\test_spec.json'
        using '.build\tests\K64F\GCC_ARM\test_spec.json'
        using '.build\tests\K64F\IAR\test_spec.json'
mbedgt: using Test Plan 'Name'
mbedgt: implemented test cases
        test case 'FLASH_SET_test_01_start'
        test case 'FLASH_SET_test_01_end'
        test case 'Control: NoRepeat'
        test case 'Control: RepeatHandler'
        test case 'Control: RepeatAll'
        test case 'Control: CaseNext'
        test case 'tests-mbedmicro-rtos-mbed-queue'
        test case 'features-feature_ipv4-tests-mbedmicro-net-nist_internet_time_service'
        test case 'tests-mbedmicro-mbed-call_before_main'
        test case 'tests-mbedmicro-rtos-mbed-mail'
        test case 'C strings: strpbrk'
        test case 'C strings: %g %g float formatting'
        test case 'C strings: %f %f float formatting'
        test case 'C strings: %u %d integer formatting'
        test case 'C strings: strtok'
        test case 'C strings: %i %d integer formatting'
        test case 'C strings: %e %E float formatting'
        test case 'C strings: %x %E integer formatting'
        test case 'READ_test_01_start'
        test case 'READ_test_01_end'
        test case 'READ_test_00'
        test case 'READ_test_02_start'
        test case 'READ_test_02_end'
        test case 'tests-mbedmicro-mbed-div'
mbedgt: conflicting test cases (name is not unique)
        test case 'Repeating Test'
        test case 'dummy test 2'
        test case 'Minimal Scheduler: Case 1'
        test case 'Control: CaseNext'
        test case 'initialize'
        test case 'Simple Test'
        test case 'dummy test'
        test case 'Minimal Scheduler: Case 2'
        test case 'Minimal Scheduler: Case 3'
```

# Testlink XML Report
An example of the outputted report is:
```
<?xml version="1.0" encoding="UTF-8"?>
<testsuite failures="0" tests="6" errors="1" time="0.149999856949">
    <testcase classname="FLASH_SET_test_01_start" host_os="Windows" name="FLASH_SET_test_01_start" time="0.0499999523163">
        <error>
    </testcase>
    <testcase classname="FLASH_SET_test_01_start" host_os="Windows" name="FLASH_SET_test_01_start" time="0.0499999523163"></testcase>
    <testcase classname="FLASH_SET_test_01_start" host_os="Windows" name="FLASH_SET_test_01_start" time="0.0499999523163"></testcase>
</testsuite>
```

# Replaces
* This PR replaces #172 