### PR TITLE
Fix for Issue 181

### DIFF
--- a/mbed_greentea/mbed_report_api.py
+++ b/mbed_greentea/mbed_report_api.py
@@ -598,7 +598,10 @@ def exporter_html(test_result_ext, test_suite_properties=None):
     # Populate a set of all of the unique tests
     for platform_toolchain, test_list in test_result_ext.iteritems():
         # Format of string is <PLATFORM>-<TOOLCHAIN>
-        platform, toolchain = platform_toolchain.split('-')
+        # <PLATFORM> can however contain '-' such as "frdm-k64f"
+        # <TOOLCHAIN> is split with '_' fortunately, as in "gcc_arm"
+        toolchain = platform_toolchain.split('-')[-1]
+        platform = platform_toolchain.replace('-%s'% toolchain, '')
         if platform in platforms_toolchains:
             platforms_toolchains[platform].append(toolchain)
         else:


### PR DESCRIPTION
# Changes
* When splitting up <PLATFORM>-<TOOLCHAIN>, we now only take the last element of the split (the toolchain, as it should not contain a '-'), and then remove that from the original string to get the platform
* Problem occurred when platform contained a '-'

# Fixes
* This pull request fixes #181 