### PR TITLE
Multi-target runs now copy to the correct device

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -738,7 +738,6 @@ def main_cli(opts, args, gt_instance_uuid=None):
     target_platforms_match = 0  # Count how many platforms were actually tested with current settings
 
     test_report = {}            # Test report used to export to Junit, HTML etc...
-    muts_to_test = []           # MUTs to actually be tested
     test_queue = Queue()        # contains information about test_bin and image_path for each test case
     test_result_queue = Queue() # used to store results of each thread
     execute_threads = []        # list of threads to run test cases
@@ -771,6 +770,7 @@ def main_cli(opts, args, gt_instance_uuid=None):
         ### Select MUTS to test from list of available MUTS to start testing
         mut = None
         number_of_parallel_instances = 1
+        muts_to_test = []           # MUTs to actually be tested
         for mbed_dev in ready_mbed_devices:
             if accepted_target_ids and mbed_dev['target_id'] not in accepted_target_ids:
                 continue


### PR DESCRIPTION
This PR addresses #187. Previously if you specified multiple targets with the `-t` option, it would not copy the binary to the correct device, for example if you ran:

```
mbedgt -V -v -t K64F-GCC_ARM,NUCLEO_F401RE-GCC_ARM
```

The first test run would copy to the K64F correctly, but when the next run was supposed to copy to the NUCLEO_F401RE, it would copy to the K64F instead.

Looks like the issue was the `muts_to_test` variable. This should change between test builds, however it was being kept in global scope. I've now moved it withing the scope of the test build loop so it should reset with each iteration.

