### PR TITLE
Handle case where tests aren't in each target run

### DIFF
--- a/mbed_greentea/mbed_report_api.py
+++ b/mbed_greentea/mbed_report_api.py
@@ -366,6 +366,7 @@ TEST_RESULT_COLOURS = {
     'IOERR_SERIAL': "DarkSalmon",
     'TIMEOUT': "DarkKhaki",
     'NO_IMAGE': "DarkSalmon",
+    'NOT_RAN': 'grey'
     # 'MBED_ASSERT': "",
     # 'BUILD_FAILED': "",
 }
@@ -637,7 +638,24 @@ def exporter_html(test_result_ext, test_suite_properties=None):
         this_row = test_cell_template % test_name
         for platform, toolchains in platforms_toolchains.iteritems():
             for toolchain in toolchains:
-                test_results = test_result_ext["%s-%s" % (platform, toolchain)][test_name]
+                test_results = None
+                
+                if test_name in test_result_ext["%s-%s" % (platform, toolchain)]:
+                    test_results = test_result_ext["%s-%s" % (platform, toolchain)][test_name]
+                else:
+                    test_results = {
+                        'single_test_result': 'NOT_RAN',
+                        'elapsed_time': 0.0,
+                        'build_path': 'N/A',
+                        'build_path_abs': 'N/A',
+                        'copy_method': 'N/A',
+                        'image_path': 'N/A',
+                        'single_test_output': 'N/A',
+                        'platform_name': platform,
+                        'test_bin_name': 'N/A',
+                        'testcase_result': {}
+                    }
+                    
                 result_div_id = "target_%s_toolchain_%s_test_%s" % (platform, toolchain, test_name.replace('-', '_'))
 
                 result_overlay = get_result_overlay(result_div_id,


### PR DESCRIPTION
This was first reported by @jeromecoutant, thanks!

This addresses #186. The root cause of the issue was when exporting HTML reports, it was assumed that all the same test cases would be run on all the targets. However, this is not always true. This PR adds a 'NOT_RAN` box to a test that did not run on the current target but DID run on at least one target.

![super_awesome_not_ran_html_report](https://cloud.githubusercontent.com/assets/3123977/18332300/08b7bbec-752b-11e6-999b-438dbb299a91.png)

Please review @ConorPKeegan
FYI @mazimkhan