### PR TITLE
Patching incorrect call to os.listdir (Fixes #194)

### DIFF
--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -575,7 +575,7 @@ def get_test_spec(opts):
         # Test specification file exists in current directory
         gt_logger.gt_log("using 'test_spec.json' from current directory!")
         test_spec_file_name = 'test_spec.json'
-    elif 'BUILD' in os.listdir():
+    elif 'BUILD' in os.listdir(os.getcwd()):
         # Checking 'BUILD' directory for test specifications
         # Using `os.listdir()` since it preserves case
         test_spec_file_name_list = get_all_test_specs_from_build_dir('BUILD')


### PR DESCRIPTION
In my last PR (https://github.com/ARMmbed/greentea/pull/193), I submitted a bad patch that made a call to `os.listdir` incorrectly. This was noticed by @jeromecoutant in #194. This commit should fix that and restore `mbedgt --list` functionality.

Please review @mazimkhan 