### PR TITLE
Searching project recursively for target information

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -410,6 +410,12 @@ def run_test_thread(test_result_queue, test_queue, opts, mut, build, build_path,
     test_platforms_match = 0
     test_report = {}
 
+    disk = mut['mount_point']
+    port = mut['serial_port']
+    micro = mut['platform_name']
+    program_cycle_s = get_platform_property(micro, "program_cycle_s")
+    forced_reset_timeout = get_platform_property(micro, "forced_reset_timeout")
+
     while not test_queue.empty():
         try:
             test = test_queue.get(False)
@@ -419,11 +425,6 @@ def run_test_thread(test_result_queue, test_queue, opts, mut, build, build_path,
 
         test_result = 'SKIPPED'
 
-        disk = mut['mount_point']
-        port = mut['serial_port']
-        micro = mut['platform_name']
-        program_cycle_s = get_platform_property(micro, "program_cycle_s")
-        forced_reset_timeout = get_platform_property(micro, "forced_reset_timeout")
         copy_method = opts.copy_method if opts.copy_method else 'shell'
         verbose = opts.verbose_test_result_only
         enum_host_tests_path = get_local_host_tests_dir(opts.enum_host_tests)


### PR DESCRIPTION
This PR was spurned by the latest restructure of mbed OS. Greentea is no longer finding the target information correctly within mbed OS. There are two main changes that are included in this PR:

1) It allows greentea to find inherited properties from parent targets.
2) It makes greentea perform a directory walk in search of a `targets.json` file. Previously, there were only a few hardcoded locations that were searched for this file. This operation is more expensive unfortunately, however it is a far more robust solution. It no longer makes assumptions on the project's structure. It should be resilient against any more changes made to the structure of mbed OS.

The performance on my machine was ~1 second for every call to `get_platform_property_from_targets`. I moved the call to this function outside of the test case loop to reduce the total number of calls.

Please review @mazimkhan 
FYI @screamerbg (thanks for reporting this issue!)