### PR TITLE
Scrubbing log of unprintable characters

### DIFF
--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -21,6 +21,7 @@ import re
 import os
 import sys
 import json
+import string
 from time import time
 from subprocess import Popen, PIPE, STDOUT
 
@@ -292,6 +293,7 @@ def run_host_test(image_path,
     end_time = time()
     testcase_duration = end_time - start_time   # Test case duration from reset to {end}
 
+    htrun_output = get_printable_string(htrun_output)
     result = get_test_result(htrun_output)
     result_test_cases = get_testcase_result(htrun_output)
     test_cases_summary = get_testcase_summary(htrun_output)
@@ -398,6 +400,9 @@ def get_coverage_data(build_path, output):
             except Exception as e:
                 gt_logger.gt_log_err("error while handling GCOV data: " + str(e))
             gt_logger.gt_log_tab("storing %d bytes in '%s'"% (len(bin_gcov_payload), gcov_path))
+
+def get_printable_string(unprintable_string):
+    return filter(lambda x: x in string.printable, unprintable_string)
 
 def get_testcase_summary(output):
     """! Searches for test case summary


### PR DESCRIPTION
If a test contains invalid ASCII characters and you attempt to export to JSON or HTML, you will receive a traceback. You can reproduce this by using commit 8a9a2463563af3ffb8d289905d3f7073a46ecc80 of mbed-os and running the following commands:

```
mbed test --compile -m NCS36510 -t GCC_ARM -n tests-mbedmicro-mbed-cpp
[...]
mbed test --run -m NCS36510 -t GCC_ARM -n tests-mbedmicro-mbed-cpp --report-html report.html -v
[...]
mbedgt: exporting to HTML file 'C:/mbed_jenkins/test_node_2/workspace/tm_wrap/754/.axes/target/NCS36510/toolchain/GCC_ARM/test_report_NCS36510-GCC_ARM.html'...
mbedgt: unexpected error:
	'ascii' codec can't decode byte 0xff in position 1348: ordinal not in range(128)
Traceback (most recent call last):
  File "c:\python27\Lib\runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "c:\python27\Lib\runpy.py", line 72, in _run_code
    exec code in run_globals
  File "c:\mbed_jenkins\test_node_2\workspace\tm_wrap\754\.env\scripts\mbedgt.exe\__main__.py", line 9, in <module>
  File "c:\mbed_jenkins\test_node_2\workspace\tm_wrap\754\.env\lib\site-packages\mbed_greentea\mbed_greentea_cli.py", line 389, in main
    cli_ret = main_cli(opts, args)
  File "c:\mbed_jenkins\test_node_2\workspace\tm_wrap\754\.env\lib\site-packages\mbed_greentea\mbed_greentea_cli.py", line 1012, in main_cli
    html_report = exporter_html(test_report)
  File "c:\mbed_jenkins\test_node_2\workspace\tm_wrap\754\.env\lib\site-packages\mbed_greentea\mbed_report_api.py", line 674, in exporter_html
    test_results)
  File "c:\mbed_jenkins\test_node_2\workspace\tm_wrap\754\.env\lib\site-packages\mbed_greentea\mbed_report_api.py", line 565, in get_result_overlay
    overlay_dropdowns = get_result_overlay_dropdowns(result_div_id, test_results)
  File "c:\mbed_jenkins\test_node_2\workspace\tm_wrap\754\.env\lib\site-packages\mbed_greentea\mbed_report_api.py", line 529, in get_result_overlay_dropdowns
    output_text=True)
  File "c:\mbed_jenkins\test_node_2\workspace\tm_wrap\754\.env\lib\site-packages\mbed_greentea\mbed_report_api.py", line 446, in get_dropdown_html
    content)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xff in position 1348: ordinal not in range(128)
```

To prevent this, this PR scrubs the htrun output of all non-printable characters.

Please review @mazimkhan 