### PR TITLE
Fixes issue #198 where an error occurs when trying to use the endswith()

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -778,17 +778,18 @@ def main_cli(opts, args, gt_instance_uuid=None):
             if accepted_target_ids and mbed_dev['target_id'] not in accepted_target_ids:
                 continue
 
+            # Check that we have a valid serial port detected.
+            sp = mbed_dev['serial_port']
+            if not sp:
+                gt_logger.gt_log_err("Serial port for target %s not detected correctly\n" % mbed_dev['target_id'])
+                continue
+
             if mbed_dev['platform_name'] == platform_name:
                 # We will force configuration specific baudrate by adding baudrate to serial port
                 # Only add baudrate decoration for serial port if it's not already there
                 # Format used by mbedhtrun: 'serial_port' = '<serial_port_name>:<baudrate>'
-                sp = mbed_dev['serial_port']
-                if sp:
-                    if not sp.endswith(str(baudrate)):
-                        mbed_dev['serial_port'] = "%s:%d" % (mbed_dev['serial_port'], baudrate)
-                else:
-                    gt_logger.gt_log_err("Serial port for target %s not detected correctly\n" % mbed_dev['target_id'])
-                    continue
+                if not sp.endswith(str(baudrate)):
+                    mbed_dev['serial_port'] = "%s:%d" % (mbed_dev['serial_port'], baudrate)
 
                 mut = mbed_dev
                 if mbed_dev not in muts_to_test:

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -782,8 +782,14 @@ def main_cli(opts, args, gt_instance_uuid=None):
                 # We will force configuration specific baudrate by adding baudrate to serial port
                 # Only add baudrate decoration for serial port if it's not already there
                 # Format used by mbedhtrun: 'serial_port' = '<serial_port_name>:<baudrate>'
-                if not mbed_dev['serial_port'].endswith(str(baudrate)):
-                    mbed_dev['serial_port'] = "%s:%d" % (mbed_dev['serial_port'], baudrate)
+                sp = mbed_dev['serial_port']
+                if sp:
+                    if not sp.endswith(str(baudrate)):
+                        mbed_dev['serial_port'] = "%s:%d" % (mbed_dev['serial_port'], baudrate)
+                else:
+                    gt_logger.gt_log_err("Serial port for target %s not detected correctly\n" % mbed_dev['target_id'])
+                    continue
+
                 mut = mbed_dev
                 if mbed_dev not in muts_to_test:
                     # We will only add unique devices to list of devices "for testing" in this test run


### PR DESCRIPTION
method on a NoneType.

On windows 7 if a target was detected but for some reason the serial port
was not, then mbed-ls would return a NoneType for the serial port field in
the ready_mbed_devices list. This serial port field under normal
circumstances will contain a string and has the endswith() method called
on it. This is however illegal for a NoneType.
The fix is to read the serial port field first and test whether or not it
is the NoneType prior to calling the method. If it is the NoneType then
report an error and skip this target.