### PR TITLE
Add line about contributing to Greentea in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Greentea is the automated testing tool for mbed OS development. It automates the
 
 This document should help you start using Greentea. Please see the [htrun documentation](https://github.com/ARMmbed/htrun), the tool Greentea uses to drive tests, for the technical details of the interactions between the platform and the host machine.
 
+Because Greentea is an open source project, we accept contributions! Please see our [contributing document](CONTRIBUTING.md) for more information.
+
 ### Prerequistes
 
 Greentea requires [Python version 2.7](https://www.python.org/downloads/). It supports the following OSes:


### PR DESCRIPTION
@iriark01 suggested that we add a line to Greentea's docs describing how to contribute to the project since it's not located in the mbed OS repository. Greentea's README is in the Handbook now, so this provides a link to the contributing doc. The conversation can be found here: https://github.com/ARMmbed/Handbook/pull/145.

Could you please review @AnotherButler? Also @mazimkhan and/or @adbridge.