### PR TITLE
SYNC failure case added: Dependent on HTRUN code

### DIFF
--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -48,6 +48,7 @@ TEST_RESULT_TIMEOUT = "TIMEOUT"
 TEST_RESULT_NO_IMAGE = "NO_IMAGE"
 TEST_RESULT_MBED_ASSERT = "MBED_ASSERT"
 TEST_RESULT_BUILD_FAILED = "BUILD_FAILED"
+TEST_RESULT_SYNC_FAILED = "SYNC_FAILED"
 
 TEST_RESULTS = [TEST_RESULT_OK,
                 TEST_RESULT_FAIL,
@@ -60,7 +61,8 @@ TEST_RESULTS = [TEST_RESULT_OK,
                 TEST_RESULT_TIMEOUT,
                 TEST_RESULT_NO_IMAGE,
                 TEST_RESULT_MBED_ASSERT,
-                TEST_RESULT_BUILD_FAILED
+                TEST_RESULT_BUILD_FAILED,
+                TEST_RESULT_SYNC_FAILED
                 ]
 
 TEST_RESULT_MAPPING = {"success" : TEST_RESULT_OK,
@@ -74,7 +76,8 @@ TEST_RESULT_MAPPING = {"success" : TEST_RESULT_OK,
                        "timeout" : TEST_RESULT_TIMEOUT,
                        "no_image" : TEST_RESULT_NO_IMAGE,
                        "mbed_assert" : TEST_RESULT_MBED_ASSERT,
-                       "build_failed" : TEST_RESULT_BUILD_FAILED
+                       "build_failed" : TEST_RESULT_BUILD_FAILED,
+                       "sync_failed" : TEST_RESULT_SYNC_FAILED
                        }
 
 


### PR DESCRIPTION
@bridadan @mazimkhan @studavekar : Please review code

Many boards in CI fail just after sync, suggestion to which was re-flash firmware and re-try. Capturing SYNC failure as separate for such cases.
Also would like to know more about SYNC=2 value, increasing that will have impact on anything?\

Note: Code changes in htrun should be pulled along with this request