### PR TITLE
Fixing parsing of memory of metrics.

### DIFF
--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -536,13 +536,16 @@ def get_memory_metrics(output):
             thread_stack_size = int(thread_stack_size)
             thread_entry_arg_split = thread_entry_arg.split('-')
             thread_entry = thread_entry_arg_split[0]
-            thread_arg = thread_entry_arg_split[1]
+
             thread_info[thread_entry_arg] = {
                 'entry': thread_entry,
-                'arg': thread_arg,
                 'max_stack': thread_max_stack,
                 'stack_size': thread_stack_size
             }
+
+            if len(thread_entry_arg_split) > 1:
+                thread_arg = thread_entry_arg_split[1]
+                thread_info[thread_entry_arg]['arg'] = thread_arg
 
     thread_info_list = thread_info.values()
 


### PR DESCRIPTION
In mbed OS versions 5.4.x and older, memory metrics were printed in a
format that always included a hyphenated thread "entry" and "argument".
In the coming 5.5 release, this doesn't appear to be the case, only
containing the "entry". This PR allows greentea to parse both cases.

@adbridge @mazimkhan This will be a necessary patch to include in the next release of greentea as this is currently broken on master (not the current release version, this only became an issue when #203 was merged).