### PR TITLE
Add reserved memory reporting

### DIFF
--- a/mbed_greentea/mbed_report_api.py
+++ b/mbed_greentea/mbed_report_api.py
@@ -775,6 +775,10 @@ def exporter_memory_metrics_csv(test_result_ext, test_suite_properties=None):
                     report_key = '%s_%s_max_heap_usage' % (target_name, test_suite_name)
                     metrics_report[report_key] = memory_metrics['max_heap']
 
+                if 'reserved_heap' in memory_metrics:
+                    report_key = '%s_%s_reserved_heap_usage' % (target_name, test_suite_name)
+                    metrics_report[report_key] = memory_metrics['reserved_heap']
+
                 if 'thread_stack_summary' in memory_metrics:
                     thread_stack_summary = memory_metrics['thread_stack_summary']
 
@@ -789,6 +793,10 @@ def exporter_memory_metrics_csv(test_result_ext, test_suite_properties=None):
                     if 'max_stack_usage_total' in thread_stack_summary:
                         report_key = '%s_%s_max_stack_usage_total' % (target_name, test_suite_name)
                         metrics_report[report_key] = thread_stack_summary['max_stack_usage_total']
+
+                    if 'reserved_stack_total' in thread_stack_summary:
+                        report_key = '%s_%s_reserved_stack_total' % (target_name, test_suite_name)
+                        metrics_report[report_key] = thread_stack_summary['reserved_stack_total']
 
     column_names = sorted(metrics_report.keys())
     column_values = [str(metrics_report[x]) for x in column_names]


### PR DESCRIPTION
Note: I have no idea what I'm doing!

But we are looking to add the reporting of the reserved memory regions (heap and stack). This seemed to do it, but feel free to be critical of our approach.

Sidenote: we're also looking to add the full memory regions (total rom/ram on a device) but this info is currently not available.

dependent on https://github.com/ARMmbed/greentea/pull/223, https://github.com/ARMmbed/mbed-os/pull/4504
commit range: https://github.com/ARMmbed/greentea/pull/228/commits/2a6a366100f06a0f29c4d0f6db5787650068107b
cc @studavekar, @bridadan 