### PR TITLE
Fixing regex that caused testcase names to be missed.

### DIFF
--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -341,8 +341,8 @@ def get_testcase_count_and_names(output):
     testcase_count = 0
     testcase_names = []
 
-    re_tc_count = re.compile(r"^\[(\d+\.\d+)\]\[(\w+)\]\[(\w+)\] \{\{(__testcase_count);(\d+)\}\}")
-    re_tc_names = re.compile(r"^\[(\d+\.\d+)\]\[(\w+)\]\[(\w+)\] \{\{(__testcase_name);([^;]+)\}\}")
+    re_tc_count = re.compile(r"^\[(\d+\.\d+)\]\[(\w+)\]\[(\w+)\].*\{\{(__testcase_count);(\d+)\}\}")
+    re_tc_names = re.compile(r"^\[(\d+\.\d+)\]\[(\w+)\]\[(\w+)\].*\{\{(__testcase_name);([^;]+)\}\}")
 
     for line in output.splitlines():
 


### PR DESCRIPTION
Handled key value pairs stopped being printed in their raw received form
in https://github.com/ARMmbed/htrun/pull/130. This broke the testcase name detection in greentea.
This changes the regex to detect the testcase names in both old and new
versions of htrun.

This should address #231 I believe.

cc @mazimkhan 