### PR TITLE
take sync flag arguments and pass to mbedhtrun

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -281,6 +281,11 @@ def main():
                     default=None,
                     help='Shuffle seed (If you want to reproduce your shuffle order please use seed provided in test summary)')
 
+    parser.add_option('', '--sync',
+                    dest='sync_packet',
+                    default=5,
+                    help='Define how many times __sync packet will be sent to device: 0: none; -1: forever; 1,2,3... - number of  times (Default 2 time)')
+
     parser.add_option('', '--lock',
                     dest='lock_by_target',
                     default=False,
@@ -465,6 +470,7 @@ def run_test_thread(test_result_queue, test_queue, opts, mut, build, build_path,
                                          json_test_cfg=opts.json_test_configuration,
                                          enum_host_tests_path=enum_host_tests_path,
                                          global_resource_mgr=opts.global_resource_mgr,
+                                         sync_packet=opts.sync_packet,
                                          verbose=verbose)
 
         # Some error in htrun, abort test execution

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -282,9 +282,9 @@ def main():
                     help='Shuffle seed (If you want to reproduce your shuffle order please use seed provided in test summary)')
 
     parser.add_option('', '--sync',
-                    dest='sync_packet',
+                    dest='num_sync_packtes',
                     default=5,
-                    help='Define how many times __sync packet will be sent to device: 0: none; -1: forever; 1,2,3... - number of  times (Default 5 time)')
+                    help='Define how many times __sync packet will be sent to device: 0: none; -1: forever; 1,2,3... - number of  times (the default is 5 packets)')
 
     parser.add_option('', '--lock',
                     dest='lock_by_target',
@@ -470,7 +470,7 @@ def run_test_thread(test_result_queue, test_queue, opts, mut, build, build_path,
                                          json_test_cfg=opts.json_test_configuration,
                                          enum_host_tests_path=enum_host_tests_path,
                                          global_resource_mgr=opts.global_resource_mgr,
-                                         sync_packet=opts.sync_packet,
+                                         num_sync_packtes=opts.num_sync_packtes,
                                          verbose=verbose)
 
         # Some error in htrun, abort test execution

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -284,7 +284,7 @@ def main():
     parser.add_option('', '--sync',
                     dest='sync_packet',
                     default=5,
-                    help='Define how many times __sync packet will be sent to device: 0: none; -1: forever; 1,2,3... - number of  times (Default 2 time)')
+                    help='Define how many times __sync packet will be sent to device: 0: none; -1: forever; 1,2,3... - number of  times (Default 5 time)')
 
     parser.add_option('', '--lock',
                     dest='lock_by_target',

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -121,7 +121,7 @@ def run_host_test(image_path,
                   max_failed_properties=5,
                   enum_host_tests_path=None,
                   global_resource_mgr=None,
-                  sync_packet=None,
+                  num_sync_packtes=None,
                   run_app=None):
     """! This function runs host test supervisor (executes mbedhtrun) and checks output from host test process.
     @param image_path Path to binary file for flashing
@@ -137,7 +137,7 @@ def run_host_test(image_path,
     @param json_test_cfg Additional test configuration file path passed to host tests in JSON format
     @param max_failed_properties After how many unknown properties we will assume test is not ported
     @param enum_host_tests_path Directory where locally defined host tests may reside
-    @param sync_packet sync packets to send for host <---> device communication
+    @param num_sync_packtes sync packets to send for host <---> device communication
     @param run_app Run application mode flag (we run application and grab serial port data)
     @param digest_source if None mbedhtrun will be executed. If 'stdin',
            stdin will be used via StdInObserver or file (if
@@ -271,8 +271,8 @@ def run_host_test(image_path,
         if run_app:
             cmd += ["--run"]    # -f stores binary name!
 
-    if sync_packet:
-        cmd += ["--sync",str(sync_packet)]
+    if num_sync_packtes:
+        cmd += ["--sync",str(num_sync_packtes)]
 
     gt_logger.gt_log_tab("calling mbedhtrun: %s"% " ".join(cmd), print_text=verbose)
     gt_logger.gt_log("mbed-host-test-runner: started")

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -272,7 +272,7 @@ def run_host_test(image_path,
             cmd += ["--run"]    # -f stores binary name!
 
     if sync_packet:
-        cmd+= ["--sync",sync_packet]
+        cmd += ["--sync",str(sync_packet)]
 
     gt_logger.gt_log_tab("calling mbedhtrun: %s"% " ".join(cmd), print_text=verbose)
     gt_logger.gt_log("mbed-host-test-runner: started")

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -121,6 +121,7 @@ def run_host_test(image_path,
                   max_failed_properties=5,
                   enum_host_tests_path=None,
                   global_resource_mgr=None,
+                  sync_packet=None,
                   run_app=None):
     """! This function runs host test supervisor (executes mbedhtrun) and checks output from host test process.
     @param image_path Path to binary file for flashing
@@ -136,6 +137,7 @@ def run_host_test(image_path,
     @param json_test_cfg Additional test configuration file path passed to host tests in JSON format
     @param max_failed_properties After how many unknown properties we will assume test is not ported
     @param enum_host_tests_path Directory where locally defined host tests may reside
+    @param sync_packet sync packets to send for host <---> device communication
     @param run_app Run application mode flag (we run application and grab serial port data)
     @param digest_source if None mbedhtrun will be executed. If 'stdin',
            stdin will be used via StdInObserver or file (if
@@ -268,6 +270,9 @@ def run_host_test(image_path,
             cmd += ["--test-cfg", '"%s"' % str(json_test_cfg)]
         if run_app:
             cmd += ["--run"]    # -f stores binary name!
+
+    if sync_packet:
+        cmd+= ["--sync",sync_packet]
 
     gt_logger.gt_log_tab("calling mbedhtrun: %s"% " ".join(cmd), print_text=verbose)
     gt_logger.gt_log("mbed-host-test-runner: started")


### PR DESCRIPTION
Due to transport overhead we may need to send more then 2 sync packets,
as of now using greentea doesn't have this option. This patch will enable us to
send --sync from greentea.