### PR TITLE
Add option to request allocation based on specified tags

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -286,6 +286,11 @@ def main():
                     default=5,
                     help='Define how many times __sync packet will be sent to device: 0: none; -1: forever; 1,2,3... - number of  times (the default is 5 packets)')
 
+    parser.add_option('', '--tag-filters',
+                    dest='tags',
+                    default=None,
+                    help='Filter list of available devices under test to only run on devices with the provided list of tags  [tag-filters tag1,tag]')
+
     parser.add_option('', '--lock',
                     dest='lock_by_target',
                     default=False,
@@ -471,6 +476,7 @@ def run_test_thread(test_result_queue, test_queue, opts, mut, build, build_path,
                                          enum_host_tests_path=enum_host_tests_path,
                                          global_resource_mgr=opts.global_resource_mgr,
                                          num_sync_packtes=opts.num_sync_packtes,
+                                         tags=opts.tags,
                                          verbose=verbose)
 
         # Some error in htrun, abort test execution

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -122,6 +122,7 @@ def run_host_test(image_path,
                   enum_host_tests_path=None,
                   global_resource_mgr=None,
                   num_sync_packtes=None,
+                  tags=None,
                   run_app=None):
     """! This function runs host test supervisor (executes mbedhtrun) and checks output from host test process.
     @param image_path Path to binary file for flashing
@@ -138,6 +139,8 @@ def run_host_test(image_path,
     @param max_failed_properties After how many unknown properties we will assume test is not ported
     @param enum_host_tests_path Directory where locally defined host tests may reside
     @param num_sync_packtes sync packets to send for host <---> device communication
+    @param tags Filter list of available devices under test to only run on devices with the provided list
+           of tags  [tag-filters tag1,tag]
     @param run_app Run application mode flag (we run application and grab serial port data)
     @param digest_source if None mbedhtrun will be executed. If 'stdin',
            stdin will be used via StdInObserver or file (if
@@ -273,6 +276,8 @@ def run_host_test(image_path,
 
     if num_sync_packtes:
         cmd += ["--sync",str(num_sync_packtes)]
+    if tags:
+        cmd += ["--tag-filters", tags]
 
     gt_logger.gt_log_tab("calling mbedhtrun: %s"% " ".join(cmd), print_text=verbose)
     gt_logger.gt_log("mbed-host-test-runner: started")


### PR DESCRIPTION
In the process of integrating additional tests to the CI we realized it would be helpful to be able to tag particular devices in RaaS that had unique or additional setups for tests that required them (for example a K64F with an ESP8266 or Ethernet). 

## Usage 
Take the following tag as an example. 

![image](https://user-images.githubusercontent.com/1060940/29049812-d4a54016-7b9d-11e7-92ff-6a597786e856.png)

There is a [separate htrun PR](https://github.com/ARMmbed/htrun/pull/163) up to implement this change, this PR will funnel the new argument to the htrun layer. Given that htrun change and the above tag setup, we could run tests with the following setup.

## Test Setup
```
mbedgt -g "K64F:raas_client:austin-ci-linux-001:8000" --test-spec=BUILD/tests/K64F/GCC_ARM/test_spec.json --report-html=K64F_GCC_ARM.html -e tests/host_tests/timing_drift_auto.py -v -V -n features-feature_lwip-tests-mbedmicro-net-tcp_hello_world --allocate-on-tag Ethernet                                                             
 ```

## Multiple Tags
Comma separated lists can also be supplied if multiple tags are required (device resource must match *all* of the supplied tags, it cannot be used as an 'or' list).
```
.... --allocate-on-tag Ethernet,ESP8266,...
```