### PR TITLE
Increase unit test coverage and fix some minor issues

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,8 +4,16 @@ include =
 
 [report]
 exclude_lines =
-    pragma: no cover
+    class GreenteaHook.*
     def __repr__
+    def run_test_thread.*
+    except ImportError.*
+    except IOError.*
+    except OSError.*
+    except UnicodeDecodeError.*
+    gt_logger.*
+    if __name__ == .__main__.:
+    main().*
+    pragma: no cover
     raise AssertionError
     raise NotImplementedError
-    if __name__ == .__main__.:

--- a/mbed_greentea/cmake_handlers.py
+++ b/mbed_greentea/cmake_handlers.py
@@ -115,7 +115,7 @@ def list_binaries_for_builds(test_spec, verbose_footer=False):
     """
     test_builds = test_spec.get_test_builds()
     for tb in test_builds:
-        gt_logger.gt_log("available tests for built '%s', location '%s'"% (tb.get_name(), tb.get_path()))
+        gt_logger.gt_log("available tests for build '%s', location '%s'"% (tb.get_name(), tb.get_path()))
         for tc in sorted(tb.get_tests().keys()):
             gt_logger.gt_log_tab("test '%s'"% tc)
 

--- a/mbed_greentea/mbed_common_api.py
+++ b/mbed_greentea/mbed_common_api.py
@@ -39,8 +39,6 @@ def run_cli_command(cmd, shell=True, verbose=False):
         if verbose:
             print("mbedgt: [ret=%d] Command: %s"% (int(ret), cmd))
             print(str(e))
-            print("mbedgt: traceback...")
-            print(e.child_traceback)
     return (result, ret)
 
 def run_cli_process(cmd):
@@ -52,7 +50,7 @@ def run_cli_process(cmd):
         p = Popen(cmd, stdout=PIPE, stderr=PIPE)
         _stdout, _stderr = p.communicate()
     except OSError as e:
-        print("mbedgt: [ret=%d] Command: %s"% (int(ret), p.returncode))
+        print("mbedgt: Command: %s"% (cmd))
         print(str(e))
         print("mbedgt: traceback...")
         print(e.child_traceback)

--- a/mbed_greentea/mbed_greentea_dlm.py
+++ b/mbed_greentea/mbed_greentea_dlm.py
@@ -123,7 +123,7 @@ def greentea_release_target_id(target_id, gt_instance_uuid):
             with open(GREENTEA_KETTLE_PATH, 'w') as kettle_file:
                 json.dump(current_brew, kettle_file, indent=4)
 
-def get_json_data_from_file(json_spec_filename, verbose=False):
+def get_json_data_from_file(json_spec_filename):
     """ Loads from file JSON formatted string to data structure
     """
     result = None
@@ -138,7 +138,7 @@ def get_json_data_from_file(json_spec_filename, verbose=False):
     return result
 
 def greentea_kettle_info():
-    """ generates human friendly info about current cettle state
+    """ generates human friendly info about current kettle state
 
     @details
     {

--- a/test/mbed_gt_coverage_api.py
+++ b/test/mbed_gt_coverage_api.py
@@ -16,6 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import os
 import unittest
 from mbed_greentea import mbed_coverage_api
 
@@ -45,6 +46,19 @@ class GreenteaCoverageAPI(unittest.TestCase):
         r = mbed_coverage_api.coverage_pack_hex_payload('.6164636772.')    # '.' -> 0x00
         self.assertEqual(bytearray(b'\x00adcgr\x00'), r)
 
+    def test_coverage_dump_file_valid(self):
+        import tempfile
+
+        payload = bytearray(b'PAYLOAD')
+        handle, path = tempfile.mkstemp("test_file")
+        mbed_coverage_api.coverage_dump_file(".", path, payload)
+
+        with open(path, 'r') as f:
+            read_data = f.read()
+
+        self.assertEqual(read_data, payload.decode("utf-8"))
+        os.close(handle)
+        os.remove(path)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/mbed_gt_greentea_dlm.py
+++ b/test/mbed_gt_greentea_dlm.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+"""
+mbed SDK
+Copyright (c) 2011-2017 ARM Limited
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import os
+import six
+import sys
+import tempfile
+import unittest
+
+from lockfile import LockFile
+from mock import patch
+from mbed_greentea import mbed_greentea_dlm
+
+home_dir = tempfile.mkdtemp()
+mbed_greentea_dlm.HOME_DIR = home_dir
+mbed_greentea_dlm.GREENTEA_HOME_DIR = ".mbed-greentea"
+mbed_greentea_dlm.GREENTEA_GLOBAL_LOCK = "glock.lock"
+mbed_greentea_dlm.GREENTEA_KETTLE = "kettle.json" # active Greentea instances
+mbed_greentea_dlm.GREENTEA_KETTLE_PATH = os.path.join(mbed_greentea_dlm.HOME_DIR, mbed_greentea_dlm.GREENTEA_HOME_DIR, mbed_greentea_dlm.GREENTEA_KETTLE)
+
+
+class GreenteaDlmFunctionality(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_greentea_home_dir_init(self):
+        mbed_greentea_dlm.greentea_home_dir_init()
+
+        path = os.path.join(mbed_greentea_dlm.HOME_DIR, mbed_greentea_dlm.GREENTEA_HOME_DIR)
+        self.assertTrue(os.path.exists(path))
+
+    def test_greentea_get_app_sem(self):
+        sem, name, uuid = mbed_greentea_dlm.greentea_get_app_sem()
+        self.assertIsNotNone(sem)
+        self.assertIsNotNone(name)
+        self.assertIsNotNone(uuid)
+
+    def test_greentea_get_target_lock(self):
+        lock = mbed_greentea_dlm.greentea_get_target_lock("target-id-2")
+        path = os.path.join(mbed_greentea_dlm.HOME_DIR, mbed_greentea_dlm.GREENTEA_HOME_DIR, "target-id-2")
+        self.assertIsNotNone(lock)
+        self.assertEqual(path, lock.path)
+
+    def test_greentea_get_global_lock(self):
+        lock = mbed_greentea_dlm.greentea_get_global_lock()
+        path = os.path.join(mbed_greentea_dlm.HOME_DIR, mbed_greentea_dlm.GREENTEA_HOME_DIR, "glock.lock")
+        self.assertIsNotNone(lock)
+        self.assertEqual(path, lock.path)
+
+    def test_get_json_data_from_file_invalid_file(self):
+        result = mbed_greentea_dlm.get_json_data_from_file("null_file")
+        self.assertIsNone(result)
+
+    def test_get_json_data_from_file_invalid_json(self):
+        path = os.path.join(mbed_greentea_dlm.HOME_DIR, "test")
+
+        with open(path, "w") as f:
+            f.write("invalid json")
+
+        result = mbed_greentea_dlm.get_json_data_from_file(path)
+        self.assertEqual(result, None)
+
+        os.remove(path)
+
+    def test_get_json_data_from_file_valid_file(self):
+        path = os.path.join(mbed_greentea_dlm.HOME_DIR, "test")
+
+        with open(path, "w") as f:
+            f.write("{}")
+
+        result = mbed_greentea_dlm.get_json_data_from_file(path)
+        self.assertEqual(result, {})
+
+        os.remove(path)
+
+    def test_greentea_update_kettle(self):
+        uuid = "001"
+        mbed_greentea_dlm.greentea_update_kettle(uuid)
+
+        data = mbed_greentea_dlm.get_json_data_from_file(mbed_greentea_dlm.GREENTEA_KETTLE_PATH)
+        self.assertIsNotNone(data)
+        self.assertIn("start_time", data[uuid])
+        self.assertIn("cwd", data[uuid])
+        self.assertIn("locks", data[uuid])
+
+        self.assertEqual(data[uuid]["cwd"], os.getcwd())
+        self.assertEqual(data[uuid]["locks"], [])
+
+        # Check greentea_kettle_info()
+        output = mbed_greentea_dlm.greentea_kettle_info().splitlines()
+        line   = output[3]
+        self.assertIn(os.getcwd(), line)
+        self.assertIn(uuid, line)
+
+        # Test greentea_acquire_target_id
+        target_id = "999"
+        mbed_greentea_dlm.greentea_acquire_target_id(target_id, uuid)
+        data = mbed_greentea_dlm.get_json_data_from_file(mbed_greentea_dlm.GREENTEA_KETTLE_PATH)
+        self.assertIn(uuid, data)
+        self.assertIn("locks", data[uuid])
+        self.assertIn(target_id, data[uuid]["locks"])
+
+        # Test greentea_release_target_id
+        mbed_greentea_dlm.greentea_release_target_id(target_id, uuid)
+        data = mbed_greentea_dlm.get_json_data_from_file(mbed_greentea_dlm.GREENTEA_KETTLE_PATH)
+        self.assertIn(uuid, data)
+        self.assertIn("locks", data[uuid])
+        self.assertNotIn(target_id, data[uuid]["locks"])
+
+        # Test greentea_acquire_target_id_from_list
+        target_id = "999"
+        result = mbed_greentea_dlm.greentea_acquire_target_id_from_list([target_id], uuid)
+        data = mbed_greentea_dlm.get_json_data_from_file(mbed_greentea_dlm.GREENTEA_KETTLE_PATH)
+        self.assertEqual(result, target_id)
+        self.assertIn(uuid, data)
+        self.assertIn("locks", data[uuid])
+        self.assertIn(target_id, data[uuid]["locks"])
+
+        # Check greentea_clean_kettle()
+        mbed_greentea_dlm.greentea_clean_kettle(uuid)
+        data = mbed_greentea_dlm.get_json_data_from_file(mbed_greentea_dlm.GREENTEA_KETTLE_PATH)
+        self.assertEqual(data, {})

--- a/test/mbed_gt_hooks.py
+++ b/test/mbed_gt_hooks.py
@@ -13,7 +13,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import six
+import sys
 import unittest
+
 from mock import patch
 from mbed_greentea.mbed_greentea_hooks import GreenteaCliTestHook
 from mbed_greentea.mbed_greentea_hooks import LcovHook
@@ -26,6 +29,14 @@ class GreenteaCliTestHookTest(unittest.TestCase):
 
     def tearDown(self):
         pass
+
+    def test_format_before_run(self):
+        command = LcovHook.format_before_run("command {expansion}", None, verbose=True)
+        self.assertEqual(command, "command {expansion}")
+
+        expansions = ["test", "test2"]
+        command = LcovHook.format_before_run("command {expansion}", {"expansion": expansions}, verbose=True)
+        self.assertEqual(command, "command ['test', 'test2']")
 
     def test_expand_parameters_with_1_list(self):
         # Simple list

--- a/test/mbed_gt_report_api.py
+++ b/test/mbed_gt_report_api.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+"""
+mbed SDK
+Copyright (c) 2011-2015 ARM Limited
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import json
+import os
+import six
+import sys
+import tempfile
+import unittest
+
+from mock import patch
+from mbed_greentea import mbed_report_api
+
+class GreenteaReportApiFunctionality(unittest.TestCase):
+    def setUp(self):
+        self.test_case_data = {
+            "K64F-ARM": {
+                "suite": {
+                    "testcase_result": {
+                        "case-1": {
+                            "duration": 1.00,
+                            "time_start": 2.00,
+                            "time_end": 3.00,
+                            "result_text": "FAIL",
+                            "passed": 10,
+                            "failed": 10
+                        },
+                        "case-2": {
+                            "duration": 1.00,
+                            "time_start": 2.00,
+                            "time_end": 3.00,
+                            "result_text": "SKIPPED",
+                            "passed": 10,
+                            "failed": 10
+                        },
+                        "case-3": {
+                            "duration": 1.00,
+                            "time_start": 2.00,
+                            "time_end": 3.00,
+                            "result_text": "?",
+                            "passed": 10,
+                            "failed": 10
+                        },
+                    },
+                    "single_test_output": "OK",
+                    "platform_name": "K64F"
+                }
+            }
+        }
+
+        self.test_suite_data = {
+            "K64F-ARM": {
+                "test-1": {
+                    "testcase_result": {
+                        "build_path": ".."
+                    },
+                    "single_test_output": "OK",
+                    "single_test_result": "OK",
+                    "platform_name": "K64F",
+                    "elapsed_time": 1.2,
+                    "copy_method": "shell"
+                },
+                "test-2": {
+                    "testcase_result": {
+                        "build_path": ".."
+                    },
+                    "single_test_output": "OK",
+                    "single_test_result": "OK",
+                    "platform_name": "K64F",
+                    "elapsed_time": 1.2,
+                    "copy_method": "shell"
+                }
+            },
+            "N32F-ARM": {
+                "test-3": {
+                    "testcase_result": {
+                        "build_path": ".."
+                    },
+                    "single_test_output": "OK",
+                    "single_test_result": "OK",
+                    "platform_name": "N32F",
+                    "elapsed_time": 1.2,
+                    "copy_method": "shell"
+                }
+            }
+        }
+
+    def tearDown(self):
+        pass
+
+    def test_export_to_file(self):
+        # Invalid filepath
+        payload  = "PAYLOAD"
+        filepath = "."
+
+        sys.stdout = stdout_capture = six.StringIO()
+        result = mbed_report_api.export_to_file(filepath, payload)
+        sys.stdout = sys.__stdout__
+
+        command_output = stdout_capture.getvalue().splitlines()[0]
+        self.assertIn("file failed:", command_output)
+        self.assertEqual(result, False)
+
+        # Valid filepath
+        temp_file = tempfile.mkstemp("test_file")
+        result = mbed_report_api.export_to_file(temp_file[1], payload)
+        self.assertTrue(result)
+
+        with open(temp_file[1], 'r') as f:
+            read_data = f.read()
+
+        self.assertEqual(read_data, payload)
+        os.close(temp_file[0])
+        os.remove(temp_file[1])
+
+
+    def test_exporter_text(self):
+        result, result_ = mbed_report_api.exporter_text(self.test_suite_data)
+
+        lines = result.splitlines()
+        self.assertIn("target", lines[1])
+        self.assertIn("platform_name", lines[1])
+        self.assertIn("test suite", lines[1])
+        self.assertIn("result", lines[1])
+        self.assertIn("K64F", lines[3])
+        self.assertIn("test-1", lines[3])
+        self.assertIn("test-2", lines[4])
+        self.assertIn("test-3", lines[5])
+        self.assertIn("OK", lines[3])
+
+    def test_exporter_testcase_test(self):
+        result, result_ = mbed_report_api.exporter_testcase_text(self.test_case_data)
+
+        lines = result.splitlines()
+        self.assertIn("target", lines[1])
+        self.assertIn("platform_name", lines[1])
+        self.assertIn("test suite", lines[1])
+        self.assertIn("result", lines[1])
+
+        line = lines[3]
+        self.assertIn("K64F-ARM", line)
+        self.assertIn("suite", line)
+        self.assertIn("case-1", line)
+
+    def test_exporter_testcase_junit(self):
+        result = mbed_report_api.exporter_testcase_junit(self.test_case_data)
+        self.assertIsNotNone(result)
+
+        from xml.etree import ElementTree as ET
+        xml = ET.fromstring(result)
+
+        self.assertEqual(xml.tag, "testsuites")
+        self.assertEqual(xml.attrib["failures"], "1")
+        self.assertEqual(xml.attrib["tests"], "3")
+        self.assertEqual(xml.attrib["errors"], "1")
+        self.assertEqual(xml.attrib["time"], "3.0")
+
+        child = xml[0]
+        self.assertEqual(child.tag, "testsuite")
+        self.assertEqual(child.attrib["failures"], "1")
+        self.assertEqual(child.attrib["tests"], "3")
+        self.assertEqual(child.attrib["errors"], "1")
+        self.assertEqual(child.attrib["time"], "3.0")

--- a/test/mbed_gt_test_api.py
+++ b/test/mbed_gt_test_api.py
@@ -325,6 +325,29 @@ Plugin info: HostTestPluginBase::BasePlugin: Waiting up to 60 sec for '024000003
 [1467205014.31][HTST][INF] {{result;success}}
 """
 
+        self.OUTPUT_WITH_MEMORY_METRICS = """mbedgt: mbed-host-test-runner: started
+[1459245860.90][CONN][RXD] {{__testcase_summary;4;0}}
+[1459245860.92][CONN][INF] found KV pair in stream: {{end;success}}, queued...
+[1459245860.92][CONN][RXD] {{end;success}}
+[1459245860.92][CONN][INF] found KV pair in stream: {{max_heap_usage;2284}}, queued...
+[1459245860.92][CONN][RXD] {{end;success}}
+[1459245860.92][CONN][INF] found KV pair in stream: {{reserved_heap;124124}}, queued...
+[1459245860.92][CONN][RXD] {{end;success}}
+[1459245860.92][CONN][INF] found KV pair in stream: {{__thread_info;"BE-EF",42,24}}, queued...
+[1459245860.92][CONN][RXD] {{end;success}}
+[1459245860.92][HTST][INF] __notify_complete(True)
+[1459245860.92][CONN][RXD] {{__coverage_start;c:\Work\core-util/source/PoolAllocator.cpp.gcda;6164636772393034c2733f32...a33e...b9}}
+[1459245860.92][HTST][INF] test suite run finished after 0.90 sec...
+[1459245860.94][HTST][INF] CONN exited with code: 0
+[1459245860.94][HTST][INF] No events in queue
+[1459245860.94][HTST][INF] stopped consuming events
+[1459245860.94][HTST][INF] host test result() call skipped, received: True
+[1459245860.94][HTST][WRN] missing __exit event from DUT
+[1459245860.94][HTST][INF] calling blocking teardown()
+[1459245860.94][HTST][INF] teardown() finished
+[1459245860.94][HTST][INF] {{result;success}}
+"""
+
     def tearDown(self):
         pass
 
@@ -475,6 +498,25 @@ Plugin info: HostTestPluginBase::BasePlugin: Waiting up to 60 sec for '024000003
         self.assertEqual(r['C strings: strpbrk']['result_text'], 'SKIPPED')
         self.assertEqual(r['C strings: strtok']['result_text'], 'ERROR')
 
+
+    def test_get_test_results_empty_output(self):
+        result = mbed_test_api.get_test_result("")
+        self.assertEqual(result, "TIMEOUT")
+
+    def test_get_memory_metrics(self):
+        result = mbed_test_api.get_memory_metrics(self.OUTPUT_WITH_MEMORY_METRICS)
+
+        self.assertEqual(result[0], 2284)
+        self.assertEqual(result[1], 124124)
+        thread_info = list(result[2])[0]
+        self.assertIn("entry", thread_info)
+        self.assertEqual(thread_info["entry"], "BE")
+        self.assertIn("stack_size", thread_info)
+        self.assertEqual(thread_info["stack_size"], 24)
+        self.assertIn("max_stack", thread_info)
+        self.assertEqual(thread_info["max_stack"], 42)
+        self.assertIn("arg", thread_info)
+        self.assertEqual(thread_info["arg"], "EF")
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/mbed_gt_yotta_api.py
+++ b/test/mbed_gt_yotta_api.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+"""
+mbed SDK
+Copyright (c) 2011-2015 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import os
+import shutil
+import tempfile
+import unittest
+from mbed_greentea import mbed_yotta_api
+
+def generate_paths_and_write(data):
+    # Generate some dummy temp directories
+    curr_dir = os.getcwd()
+    temp0_dir = tempfile.mkdtemp()
+    temp1_dir = os.mkdir(os.path.join(temp0_dir, "yotta_targets"))
+    temp2_dir = os.mkdir(os.path.join(temp0_dir, "yotta_targets", "target_name"))
+
+    with open(os.path.join(os.path.join(temp0_dir, "yotta_targets", "target_name"), "target.json"), "w") as f:
+        f.write(data)
+
+    return temp0_dir
+
+class YottaApiFunctionality(unittest.TestCase):
+    def setUp(self):
+        self.curr_dir = os.getcwd()
+
+    def tearDown(self):
+        pass
+
+    def test_build_with_yotta_invalid_target_name(self):
+        res, ret = mbed_yotta_api.build_with_yotta("invalid_name", True, build_to_debug=True)
+        self.assertEqual(res, False)
+
+        res, ret = mbed_yotta_api.build_with_yotta("invalid_name", True, build_to_release=True)
+        self.assertEqual(res, False)
+
+    def test_get_platform_name_from_yotta_target_invalid_target_file(self):
+        temp0_dir = generate_paths_and_write("test")
+
+        os.chdir(temp0_dir)
+        result = mbed_yotta_api.get_platform_name_from_yotta_target("target_name")
+        self.assertEqual(result, None)
+        os.chdir(self.curr_dir)
+
+        shutil.rmtree(temp0_dir)
+
+    def test_get_platform_name_from_yotta_target_missing_keywords(self):
+        temp0_dir = generate_paths_and_write("{}")
+
+        os.chdir(temp0_dir)
+        result = mbed_yotta_api.get_platform_name_from_yotta_target("target_name")
+        self.assertEqual(result, None)
+        os.chdir(self.curr_dir)
+
+        shutil.rmtree(temp0_dir)
+
+    def test_get_platform_name_from_yotta_target_missing_targets(self):
+        temp0_dir = generate_paths_and_write('{"keywords": []}')
+
+        os.chdir(temp0_dir)
+        result = mbed_yotta_api.get_platform_name_from_yotta_target("target_name")
+        self.assertEqual(result, None)
+        os.chdir(self.curr_dir)
+
+        shutil.rmtree(temp0_dir)
+
+    def test_get_platform_name_from_yotta_target_valid_targets(self):
+        temp0_dir = generate_paths_and_write('{"keywords": ["mbed-target:K64F"]}')
+
+        os.chdir(temp0_dir)
+        result = mbed_yotta_api.get_platform_name_from_yotta_target("target_name")
+        self.assertEqual(result, "K64F")
+        os.chdir(self.curr_dir)
+
+        shutil.rmtree(temp0_dir)

--- a/test/resources/empty/test/CTestTestfile.cmake
+++ b/test/resources/empty/test/CTestTestfile.cmake
@@ -1,0 +1,6 @@
+# CMake generated Testfile for
+# Source directory: c:/Work2/mbed-client/test
+# Build directory: c:/Work2/mbed-client/build/frdm-k64f-gcc/test
+#
+# This file includes the relevant testing commands required for
+# testing this directory and lists subdirectories to be tested as well.

--- a/test/resources/not-empty/test/CTestTestfile.cmake
+++ b/test/resources/not-empty/test/CTestTestfile.cmake
@@ -1,0 +1,9 @@
+# CMake generated Testfile for
+# Source directory: c:/Work2/mbed-client/test
+# Build directory: c:/Work2/mbed-client/build/frdm-k64f-gcc/test
+#
+# This file includes the relevant testing commands required for
+# testing this directory and lists subdirectories to be tested as well.
+add_test(mbed-client-test-mbedclient-smokeTest "mbed-client-test-mbedclient-smokeTest")
+add_test(mbed-client-test-helloworld-mbedclient "mbed-client-test-helloworld-mbedclient")
+add_test()

--- a/test/resources/test_spec.json
+++ b/test/resources/test_spec.json
@@ -1,0 +1,44 @@
+{
+  "builds": {
+      "K64F-ARM": {
+          "platform": "K64F",
+          "toolchain": "ARM",
+          "base_path": "./BUILD/K64F/ARM",
+          "baud_rate": 9600,
+          "tests": {
+              "tests-example-1": {
+                  "binaries": [
+                      {
+                          "binary_type": "bootable",
+                          "path": "./BUILD/K64F/ARM/tests-mbedmicro-rtos-mbed-mail.bin"
+                      }
+                  ]
+              },
+              "tests-example-2": {
+                  "binaries": [
+                      {
+                          "binary_type": "bootable",
+                          "path": "./BUILD/K64F/ARM/tests-mbed_drivers-c_strings.bin"
+                      }
+                  ]
+              }
+          }
+      },
+      "K64F-GCC": {
+          "platform": "K64F",
+          "toolchain": "GCC_ARM",
+          "base_path": "./BUILD/K64F/GCC_ARM",
+          "baud_rate": 9600,
+          "tests": {
+              "tests-example-7": {
+                  "binaries": [
+                      {
+                          "binary_type": "bootable",
+                          "path": "./BUILD/K64F/GCC_ARM/tests-mbedmicro-rtos-mbed-mail.bin"
+                      }
+                  ]
+              }
+          }
+      }
+  }
+}


### PR DESCRIPTION
Changes:

- Fix typo in cmake_handlers log output
- Fix typo in greentea_kettle_info() docstring
- Remove unused parameter from get_json_data_from_file()
- Reduce nesting in mbed_target_info to make it easier to test