### PR TITLE
Handle pure evil non-unicode in report API

### DIFF
--- a/mbed_greentea/mbed_report_api.py
+++ b/mbed_greentea/mbed_report_api.py
@@ -42,7 +42,7 @@ def exporter_json(test_result_ext, test_suite_properties=None):
         for suite in target.values():
             try:
                 suite["single_test_output"] = suite["single_test_output"]\
-                                              .decode("unicode_escape")
+                                              .decode("utf-8", "replace")
             except KeyError:
                 pass
     return json.dumps(test_result_ext, indent=4)
@@ -603,7 +603,7 @@ def get_result_overlay_dropdowns(result_div_id, test_results):
     result_output_dropdown = get_dropdown_html(result_output_div_id,
                                                "Test Output",
                                                test_results['single_test_output']
-                                               .decode("unicode-escape")
+                                               .decode("utf-8", "replace")
                                                .rstrip("\n"),
                                                output_text=True)
 

--- a/test/report_api.py
+++ b/test/report_api.py
@@ -45,7 +45,7 @@ class ReportEmitting(unittest.TestCase):
                     u'build_path_abs': u'N/A',
                     u'copy_method': u'N/A',
                     u'image_path': u'N/A',
-                    u'single_test_output': b'N/A',
+                    u'single_test_output': b'\x80abc\uXXXX' ,
                     u'platform_name': u'k64f',
                     u'test_bin_name': u'N/A',
                     u'testcase_result': {},


### PR DESCRIPTION
Resolves #240

Note to anyone reading:

**Never, EVER, emit this byte sequence** (as text)