### PR TITLE
Fix test name globing

### DIFF
--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -23,6 +23,7 @@ import os
 import sys
 import random
 import optparse
+import fnmatch
 from time import time
 try:
     from Queue import Queue
@@ -119,18 +120,6 @@ def create_filtered_test_list(ctest_test_list, test_by_names, skip_test, test_sp
     @return
     """
 
-    def filter_names_by_prefix(test_case_name_list, prefix_name):
-        """!
-        @param test_case_name_list List of all test cases
-        @param prefix_name Prefix of test name we are looking for
-        @result Set with names of test names starting with 'prefix_name'
-        """
-        result = list()
-        for test_name in test_case_name_list:
-            if test_name.startswith(prefix_name):
-                result.append(test_name)
-        return sorted(result)
-
     filtered_ctest_test_list = ctest_test_list
     test_list = None
     invalid_test_names = []
@@ -142,18 +131,17 @@ def create_filtered_test_list(ctest_test_list, test_by_names, skip_test, test_sp
         test_list = test_by_names.split(',')
         gt_logger.gt_log("test case filter (specified with -n option)")
 
+
         for test_name in set(test_list):
-            if test_name.endswith('*'):
-                # This 'star-sufix' filter allows users to filter tests with fixed prefixes
-                # Example: -n 'TESTS-mbed_drivers* will filter all test cases with name starting with 'TESTS-mbed_drivers'
-                for test_name_filtered in filter_names_by_prefix(ctest_test_list.keys(), test_name[:-1]):
-                    gt_logger.gt_log_tab("test filtered in '%s'"% gt_logger.gt_bright(test_name_filtered))
-                    filtered_ctest_test_list[test_name_filtered] = ctest_test_list[test_name_filtered]
-            elif test_name not in ctest_test_list:
-                invalid_test_names.append(test_name)
+            gt_logger.gt_log_tab(test_name)
+            matches = [test for test in ctest_test_list.keys() if fnmatch.fnmatch(test, test_name)]
+            gt_logger.gt_log_tab(str(ctest_test_list))
+            if matches:
+                for match in matches:
+                    gt_logger.gt_log_tab("test filtered in '%s'"% gt_logger.gt_bright(match))
+                    filtered_ctest_test_list[match] = ctest_test_list[match]
             else:
-                gt_logger.gt_log_tab("test filtered in '%s'"% gt_logger.gt_bright(test_name))
-                filtered_ctest_test_list[test_name] = ctest_test_list[test_name]
+                invalid_test_names.append(test_name)
 
     if skip_test:
         test_list = skip_test.split(',')

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -131,7 +131,6 @@ def create_filtered_test_list(ctest_test_list, test_by_names, skip_test, test_sp
         test_list = test_by_names.split(',')
         gt_logger.gt_log("test case filter (specified with -n option)")
 
-
         for test_name in set(test_list):
             gt_logger.gt_log_tab(test_name)
             matches = [test for test in ctest_test_list.keys() if fnmatch.fnmatch(test, test_name)]

--- a/test/mbed_gt_cli.py
+++ b/test/mbed_gt_cli.py
@@ -21,6 +21,36 @@ import sys
 import unittest
 
 from mbed_greentea import mbed_greentea_cli
+from mbed_greentea.tests_spec import TestSpec
+
+test_spec_def = {
+    "builds": {
+        "K64F-ARM": {
+            "platform": "K64F",
+            "toolchain": "ARM",
+            "base_path": "./.build/K64F/ARM",
+            "baud_rate": 115200,
+            "tests": {
+                "mbed-drivers-test-generic_tests":{
+                    "binaries":[
+                        {
+                            "binary_type": "bootable",
+                            "path": "./.build/K64F/ARM/mbed-drivers-test-generic_tests.bin"
+                        }
+                    ]
+                },
+                "mbed-drivers-test-c_strings":{
+                    "binaries":[
+                        {
+                            "binary_type": "bootable",
+                            "path": "./.build/K64F/ARM/mbed-drivers-test-c_strings.bin"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}
 
 class GreenteaCliFunctionality(unittest.TestCase):
 
@@ -85,6 +115,23 @@ class GreenteaCliFunctionality(unittest.TestCase):
 
         os.chdir(curr_dir)
         shutil.rmtree(test1_dir)
+
+    def test_create_filtered_test_list(self):
+        test_spec = TestSpec()
+        test_spec.parse(test_spec_def)
+        test_build = test_spec.get_test_builds()[0]
+
+        test_list = mbed_greentea_cli.create_filtered_test_list(test_build.get_tests(),
+                                                                'mbed-drivers-test-generic_*',
+                                                                None,
+                                                                test_spec=test_spec)
+        self.assertEqual(set(test_list.keys()), set(['mbed-drivers-test-generic_tests']))
+
+        test_list = mbed_greentea_cli.create_filtered_test_list(test_build.get_tests(),
+                                                                '*_strings',
+                                                                None,
+                                                                test_spec=test_spec)
+        self.assertEqual(set(test_list.keys()), set(['mbed-drivers-test-c_strings']))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/mbed_gt_cli.py
+++ b/test/mbed_gt_cli.py
@@ -133,5 +133,19 @@ class GreenteaCliFunctionality(unittest.TestCase):
                                                                 test_spec=test_spec)
         self.assertEqual(set(test_list.keys()), set(['mbed-drivers-test-c_strings']))
 
+        test_list = mbed_greentea_cli.create_filtered_test_list(test_build.get_tests(),
+                                                                'mbed*s',
+                                                                None,
+                                                                test_spec=test_spec)
+        expected = set(['mbed-drivers-test-c_strings', 'mbed-drivers-test-generic_tests'])
+        self.assertEqual(set(test_list.keys()), expected)
+
+        test_list = mbed_greentea_cli.create_filtered_test_list(test_build.get_tests(),
+                                                                '*-drivers-*',
+                                                                None,
+                                                                test_spec=test_spec)
+        expected = set(['mbed-drivers-test-c_strings', 'mbed-drivers-test-generic_tests'])
+        self.assertEqual(set(test_list.keys()), expected)
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/mbed_gt_target_info.py
+++ b/test/mbed_gt_target_info.py
@@ -416,7 +416,7 @@ mbed-gcc 1.1.0
         with patch("mbed_greentea.mbed_target_info.walk") as _walk:
             _walk.return_value = iter([("", ["foo"], []), ("foo", [], ["targets.json"])])
             result = list(mbed_target_info._find_targets_json("bogus_path"))
-            self.assertEqual(result, ["foo/targets.json"])
+            self.assertEqual(result, [os.path.join("foo", "targets.json")])
 
     def test_find_targets_json_ignored(self):
         with patch("mbed_greentea.mbed_target_info.walk") as _walk:


### PR DESCRIPTION
This fixes #262. It also fixes testing on Windows since directory separators are silly.