### PR TITLE
add "--fm" option to support FastModels testing in greentea

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,21 @@ $ mbedls
 ```
 In this case, you won't test one target, the LPC1768.
 
+### Testing on Fast Model FVPs
+
+Fast Models FVPs are software models for Arm reference design platfrom
+
+Greentea supports running test on Fast Models. And [mbed-fastmodel-agent](https://github.com/ARMmbed/mbed-fastmodel-agent) module is required for this purpose. 
+
+You can run tests for FVP_MPS2_Cortex-M3 models, by '--fm' option:
+```
+$ mbedgt --fm FVP_MPS2_M3:DEFAULT
+```
+
+Where ```FVP_MPS2_M3``` is the platfrom name for the ```FVP_MPS2_Cortex-M3``` models in mbed OS.
+
+And ```DEFAULT``` is the config to the Fast Model, you can find out using ```mbedfm``` command
+
 ### Creating reports
 Greentea supports a number of report formats.
 

--- a/README.md
+++ b/README.md
@@ -582,7 +582,9 @@ In this case, you won't test one target, the LPC1768.
 
 Fast Models FVPs are software models for Arm reference design platfrom
 
-Greentea supports running test on Fast Models. And [mbed-fastmodel-agent](https://github.com/ARMmbed/mbed-fastmodel-agent) module is required for this purpose. 
+Greentea supports running test on Fast Models. And [mbed-fastmodel-agent](https://github.com/ARMmbed/mbed-fastmodel-agent) module is required for this purpose.
+
+The "--fm" option only available when the `mbed-fastmodel-agent` module is installed :  
 
 You can run tests for FVP_MPS2_Cortex-M3 models, by '--fm' option:
 ```

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -24,6 +24,7 @@ import sys
 import random
 import optparse
 import fnmatch
+import imp
 from time import time
 try:
     from Queue import Queue
@@ -257,9 +258,16 @@ def main():
                     dest='global_resource_mgr',
                     help='Global resource manager service query: platrform name, remote mgr module name, IP address and port, example K64F:module_name:10.2.123.43:3334')
 
+    # Show --fm option only if "fm_agent" module installed
+    try:
+        imp.find_module('fm_agent')
+    except ImportError:
+        fm_help=optparse.SUPPRESS_HELP
+    else:
+        fm_help='Fast Model Connection: fastmodel name, config name, example FVP_MPS2_M3:DEFAULT'
     parser.add_option('', '--fm',
                     dest='fast_model_connection',
-                    help='Fast Model Connection: fastmodel name, config name, example FVP_MPS2_M3:DEFAULT')
+                    help=fm_help)
 
     parser.add_option('-m', '--map-target',
                     dest='map_platform_to_yt_target',

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -42,7 +42,7 @@ from mbed_greentea.mbed_test_api import log_mbed_devices_in_table
 from mbed_greentea.mbed_test_api import TEST_RESULTS
 from mbed_greentea.mbed_test_api import TEST_RESULT_OK, TEST_RESULT_FAIL
 from mbed_greentea.mbed_test_api import parse_global_resource_mgr
-from mbed_greentea.mbed_test_api import parse_simulator_resource_mgr
+from mbed_greentea.mbed_test_api import parse_fast_model_connection
 from mbed_greentea.mbed_report_api import exporter_text
 from mbed_greentea.mbed_report_api import exporter_testcase_text
 from mbed_greentea.mbed_report_api import exporter_json
@@ -257,9 +257,9 @@ def main():
                     dest='global_resource_mgr',
                     help='Global resource manager service query: platrform name, remote mgr module name, IP address and port, example K64F:module_name:10.2.123.43:3334')
 
-    parser.add_option('-s', '--srm',
-                    dest='simulator_resource_mgr',
-                    help='Simulator resource manager service query: platrform name, simulator module, and config name, example FVP_MPS2_M3:fastmodel_agent:DEFAULT')
+    parser.add_option('', '--fm',
+                    dest='fast_model_connection',
+                    help='Fast Model Connection: fastmodel name, config name, example FVP_MPS2_M3:DEFAULT')
 
     parser.add_option('-m', '--map-target',
                     dest='map_platform_to_yt_target',
@@ -480,7 +480,7 @@ def run_test_thread(test_result_queue, test_queue, opts, mut, build, build_path,
                                          json_test_cfg=opts.json_test_configuration,
                                          enum_host_tests_path=enum_host_tests_path,
                                          global_resource_mgr=opts.global_resource_mgr,
-                                         simulator_resource_mgr=opts.simulator_resource_mgr,
+                                         fast_model_connection=opts.fast_model_connection,
                                          num_sync_packtes=opts.num_sync_packtes,
                                          tags=opts.tags,
                                          retry_count=opts.retry_count,
@@ -761,19 +761,19 @@ def main_cli(opts, args, gt_instance_uuid=None):
             gt_logger.gt_log("global resource manager switch '--grm %s' in wrong format!"% opts.global_resource_mgr)
             return (-1)
 
-    if opts.simulator_resource_mgr:
-        # Mocking available platform requested by --srm switch
-        srm_values = parse_simulator_resource_mgr(opts.simulator_resource_mgr)
-        if srm_values:
-            gt_logger.gt_log_warn("entering simulator resource manager mbed-ls dummy simulator mode!")
-            srm_platform_name, srm_module_name, srm_config_name = srm_values
+    if opts.fast_model_connection:
+        # Mocking available platform requested by --fm switch
+        fm_values = parse_fast_model_connection(opts.fast_model_connection)
+        if fm_values:
+            gt_logger.gt_log_warn("entering fastmodel connection, mbed-ls dummy simulator mode!")
+            fm_platform_name, fm_config_name = fm_values
             mbeds_list = []
             for _ in range(parallel_test_exec):
-                mbeds_list.append(mbeds.get_dummy_platform(srm_platform_name))
-            opts.simulator_resource_mgr = ':'.join(srm_values[1:])
-            gt_logger.gt_log_tab("adding dummy simulator platform '%s'"% srm_platform_name)
+                mbeds_list.append(mbeds.get_dummy_platform(fm_platform_name))
+            opts.fast_model_connection = fm_config_name
+            gt_logger.gt_log_tab("adding dummy fastmodel platform '%s'"% fm_platform_name)
         else:
-            gt_logger.gt_log("simulator resource manager switch '--srm %s' in wrong format!"% opts.simulator_resource_mgr)
+            gt_logger.gt_log("fast model connection switch '--fm %s' in wrong format!"% opts.fast_model_connection)
             return (-1)
 
     ready_mbed_devices = [] # Devices which can be used (are fully detected)

--- a/mbed_greentea/mbed_greentea_cli.py
+++ b/mbed_greentea/mbed_greentea_cli.py
@@ -42,6 +42,7 @@ from mbed_greentea.mbed_test_api import log_mbed_devices_in_table
 from mbed_greentea.mbed_test_api import TEST_RESULTS
 from mbed_greentea.mbed_test_api import TEST_RESULT_OK, TEST_RESULT_FAIL
 from mbed_greentea.mbed_test_api import parse_global_resource_mgr
+from mbed_greentea.mbed_test_api import parse_simulator_resource_mgr
 from mbed_greentea.mbed_report_api import exporter_text
 from mbed_greentea.mbed_report_api import exporter_testcase_text
 from mbed_greentea.mbed_report_api import exporter_json
@@ -255,6 +256,10 @@ def main():
     parser.add_option('-g', '--grm',
                     dest='global_resource_mgr',
                     help='Global resource manager service query: platrform name, remote mgr module name, IP address and port, example K64F:module_name:10.2.123.43:3334')
+
+    parser.add_option('-s', '--srm',
+                    dest='simulator_resource_mgr',
+                    help='Simulator resource manager service query: platrform name, simulator module, and config name, example FVP_MPS2_M3:fastmodel_agent:DEFAULT')
 
     parser.add_option('-m', '--map-target',
                     dest='map_platform_to_yt_target',
@@ -475,6 +480,7 @@ def run_test_thread(test_result_queue, test_queue, opts, mut, build, build_path,
                                          json_test_cfg=opts.json_test_configuration,
                                          enum_host_tests_path=enum_host_tests_path,
                                          global_resource_mgr=opts.global_resource_mgr,
+                                         simulator_resource_mgr=opts.simulator_resource_mgr,
                                          num_sync_packtes=opts.num_sync_packtes,
                                          tags=opts.tags,
                                          retry_count=opts.retry_count,
@@ -753,6 +759,21 @@ def main_cli(opts, args, gt_instance_uuid=None):
             gt_logger.gt_log_tab("adding dummy platform '%s'"% grm_platform_name)
         else:
             gt_logger.gt_log("global resource manager switch '--grm %s' in wrong format!"% opts.global_resource_mgr)
+            return (-1)
+
+    if opts.simulator_resource_mgr:
+        # Mocking available platform requested by --srm switch
+        srm_values = parse_simulator_resource_mgr(opts.simulator_resource_mgr)
+        if srm_values:
+            gt_logger.gt_log_warn("entering simulator resource manager mbed-ls dummy simulator mode!")
+            srm_platform_name, srm_module_name, srm_config_name = srm_values
+            mbeds_list = []
+            for _ in range(parallel_test_exec):
+                mbeds_list.append(mbeds.get_dummy_platform(srm_platform_name))
+            opts.simulator_resource_mgr = ':'.join(srm_values[1:])
+            gt_logger.gt_log_tab("adding dummy simulator platform '%s'"% srm_platform_name)
+        else:
+            gt_logger.gt_log("simulator resource manager switch '--srm %s' in wrong format!"% opts.simulator_resource_mgr)
             return (-1)
 
     ready_mbed_devices = [] # Devices which can be used (are fully detected)

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -163,7 +163,7 @@ def run_host_test(image_path,
                   max_failed_properties=5,
                   enum_host_tests_path=None,
                   global_resource_mgr=None,
-                  simulator_resource_mgr=None,
+                  fast_model_connection=None,
                   num_sync_packtes=None,
                   retry_count=1,
                   tags=None,
@@ -296,11 +296,11 @@ def run_host_test(image_path,
         if run_app:
             cmd += ["--run"]    # -f stores binary name!
 
-    if simulator_resource_mgr:
+    if fast_model_connection:
         # Use simulator resource manager to execute test
         # Example:
-        # $ mbedhtrun -f "tests-mbed_drivers-generic_tests.elf" -m FVP_MPS2_M3 --srm fastmodel_agent:DEFAULT
-        cmd += ['--srm', simulator_resource_mgr]
+        # $ mbedhtrun -f "tests-mbed_drivers-generic_tests.elf" -m FVP_MPS2_M3 --fm DEFAULT
+        cmd += ['--fm', fast_model_connection]
 
     if program_cycle_s:
         cmd += ["-C", str(program_cycle_s)]
@@ -772,13 +772,12 @@ def parse_global_resource_mgr(global_resource_mgr):
         return False
     return platform_name, module_name, ip_name, port_name
 
-def parse_simulator_resource_mgr(simulator_resource_mgr):
-    """! Parses --srm switch with simulator resource manager info
-    @details FVP_MPS2_M3:fastmodel_agent:DEFAULT
-    @return tuple wity four elements from SRM or None if error
+def parse_fast_model_connection(fast_model_connection):
+    """! Parses --fm switch with simulator resource manager info
+    @details FVP_MPS2_M3:DEFAULT
     """
     try:
-        platform_name, module_name, config_name = simulator_resource_mgr.split(':')
+        platform_name, config_name = fast_model_connection.split(':')
     except ValueError as e:
         return False
-    return platform_name, module_name, config_name
+    return platform_name, config_name

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -163,6 +163,7 @@ def run_host_test(image_path,
                   max_failed_properties=5,
                   enum_host_tests_path=None,
                   global_resource_mgr=None,
+                  simulator_resource_mgr=None,
                   num_sync_packtes=None,
                   retry_count=1,
                   tags=None,
@@ -294,6 +295,12 @@ def run_host_test(image_path,
             cmd += ["-r", reset]
         if run_app:
             cmd += ["--run"]    # -f stores binary name!
+
+    if simulator_resource_mgr:
+        # Use simulator resource manager to execute test
+        # Example:
+        # $ mbedhtrun -f "tests-mbed_drivers-generic_tests.elf" -m FVP_MPS2_M3 --srm fastmodel_agent:DEFAULT
+        cmd += ['--srm', simulator_resource_mgr]
 
     if program_cycle_s:
         cmd += ["-C", str(program_cycle_s)]
@@ -764,3 +771,14 @@ def parse_global_resource_mgr(global_resource_mgr):
     except ValueError as e:
         return False
     return platform_name, module_name, ip_name, port_name
+
+def parse_simulator_resource_mgr(simulator_resource_mgr):
+    """! Parses --srm switch with simulator resource manager info
+    @details FVP_MPS2_M3:fastmodel_agent:DEFAULT
+    @return tuple wity four elements from SRM or None if error
+    """
+    try:
+        platform_name, module_name, config_name = simulator_resource_mgr.split(':')
+    except ValueError as e:
+        return False
+    return platform_name, module_name, config_name


### PR DESCRIPTION
# Description

In order to support FastModels in mbed testing framework, an extra option "--fm" been added to greentea.

This option will allow greentea hooks up with fm_agent module, and run tests over FastModels

The command line format of the --fm is following the RaaS_Client "--grm" convention


# Details
* "--fm" been added to mbedgt
* user could use __mbedgt  --fm \<model_name>:<config_name>__
  * e.g.  __mbedgt  --srm FVP_MSP2_M3:DEFAULT__


This PR is related with other PRs regarding to FastModel support in testing framework 
ARMmbed/mbed-ls#345
ARMmbed/htrun#187


CC. @theotherjimmy @studavekar @bridadan dan @bulislaw 