### PR TITLE
add try/exception to handle UnicodeDecodeError

### DIFF
--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -134,7 +134,7 @@ def run_htrun(cmd, verbose):
         try:
             htrun_output += line.decode('utf-8')
         except UnicodeDecodeError:
-            pass
+            gt_logger.gt_log_err("UnicodeDecodeError encountered!")
         # When dumping output to file both \r and \n will be a new line
         # To avoid this "extra new-line" we only use \n at the end
 
@@ -146,7 +146,7 @@ def run_htrun(cmd, verbose):
             try:
                 sys.stdout.write(line.decode('utf-8').rstrip() + '\n')
             except UnicodeDecodeError:
-                pass
+                gt_logger.gt_log_err("UnicodeDecodeError encountered!")
             sys.stdout.flush()
 
     # Check if process was terminated by signal

--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -131,7 +131,10 @@ def run_htrun(cmd, verbose):
     htrun_failure_line = re.compile('\[RXD\] (:\d+::FAIL: .*)')
 
     for line in iter(p.stdout.readline, b''):
-        htrun_output += line.decode('utf-8')
+        try:
+            htrun_output += line.decode('utf-8')
+        except UnicodeDecodeError:
+            pass
         # When dumping output to file both \r and \n will be a new line
         # To avoid this "extra new-line" we only use \n at the end
 
@@ -140,7 +143,10 @@ def run_htrun(cmd, verbose):
             gt_logger.gt_log_err(test_error.group(1))
 
         if verbose:
-            sys.stdout.write(line.decode('utf-8').rstrip() + '\n')
+            try:
+                sys.stdout.write(line.decode('utf-8').rstrip() + '\n')
+            except UnicodeDecodeError:
+                pass
             sys.stdout.flush()
 
     # Check if process was terminated by signal


### PR DESCRIPTION
Due to lack of pull-up on different parts, the re-initialization of uart causes it to send an invalid character which we are not able to handle properly on greentea side. While partners are investigating the issue and fix, we will add this change in to handle the exception gracefully, as this bug is blocking the addition of multiple parts to our CI.