### PR TITLE
Checking decoded output for test errors

### DIFF
--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -136,7 +136,7 @@ def run_htrun(cmd, verbose):
         # When dumping output to file both \r and \n will be a new line
         # To avoid this "extra new-line" we only use \n at the end
 
-        test_error = htrun_failure_line.search(line)
+        test_error = htrun_failure_line.search(decoded_line)
         if test_error:
             gt_logger.gt_log_err(test_error.group(1))
 


### PR DESCRIPTION
This is cleaning up a slight implementation detail from #289. I missed this line when making the change. This means all checks in greentea are now using the decoded output.