### PR TITLE
Fix encode failure

### DIFF
--- a/mbed_greentea/mbed_test_api.py
+++ b/mbed_greentea/mbed_test_api.py
@@ -141,11 +141,16 @@ def run_htrun(cmd, verbose):
             gt_logger.gt_log_err(test_error.group(1))
 
         if verbose:
-            sys.stdout.write(decoded_line.rstrip() + '\n')
+            output = decoded_line.rstrip() + '\n'
+            try:
+                sys.stdout.write(output.encode("utf-8"))
+            except TypeError:
+                sys.stdout.write(output)
             sys.stdout.flush()
 
     # Check if process was terminated by signal
     returncode = p.wait()
+
     return returncode, htrun_output
 
 def run_host_test(image_path,

--- a/test/mbed_gt_test_api.py
+++ b/test/mbed_gt_test_api.py
@@ -18,6 +18,7 @@ limitations under the License.
 
 import unittest
 from mbed_greentea import mbed_test_api
+from mock import patch, MagicMock
 
 
 
@@ -591,6 +592,16 @@ Plugin info: HostTestPluginBase::BasePlugin: Waiting up to 60 sec for '024000003
     def test_get_testcase_result_start_tag_missing(self):
         result = mbed_test_api.get_testcase_result(self.OUTPUT_STARTTAG_MISSING)
         self.assertEqual(result['DNS query']['utest_log'], "__testcase_start tag not found.")
+
+    def test_run_htrun_unicode(self):
+        with patch("mbed_greentea.mbed_test_api.run_command") as _run_command:
+            read_line_mock = MagicMock()
+            read_line_mock.decode = MagicMock(return_value=u"\u036b")
+            p_mock = MagicMock()
+            p_mock.wait = MagicMock(return_value=1337)
+            p_mock.stdout.readline = MagicMock(side_effect=[read_line_mock])
+            _run_command.return_value = p_mock
+            returncode, htrun_output = mbed_test_api.run_htrun("dummy", True)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This should fix #294. Certain characters (typically triggered by corrupted data coming over a device's serial line) can cause greentea to crash when printing them to the console. This seems to only be an issue with Python 2.7. Handling this case universally between Python 2.7 and 3.x turns out to be quite challenging and I didn't really find any solutions I was completely happy with. This was the best compromise I could find.

Python 2.7 is perfectly happy to accept "byte-like" strings when writing to stdout. This also fixes the traceback described in #294. Python 3.x however requires "string-like" strings, so that is what the `try/except` block is doing. I also realize my terminology is off, but I looked at it for quite sometime and I still don't completely understand it. The good news is, [we probably only have to support Python 2.7 until the end of this year](https://pythonclock.org/), so I may not have to fully understand it 😄 