### PR TITLE
HTRUN : add STM32CubeProgrammer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,15 @@ List available reset and flashing plugins:
 $ htrun --plugins
 ```
 
-Flash binary file `/path/to/file/binary.bin` using plugin `stlink`. Use serial port `COM4` with baudrate `115200` to communicate with DUT:
+Note that some plugin could need some manual installation for extra application before.
+
+Ex: Flash binary file `/path/to/file/binary.bin` using STM32CubeProgrammer tool. Use serial port `COM4` with baudrate `115200` to communicate with DUT:
 
 ```
-htrun -c stlink -f /path/to/file/binary.bin -p COM4:115200
+htrun -c stprog -f /path/to/file/binary.bin -p COM4:115200
 ```
+
+In this example, `STM32_Programmer_CLI` [application](https://www.st.com/en/development-tools/stm32cubeprog.html) has to be in the environment path.
 
 # Installation
 

--- a/src/htrun/host_tests_plugins/__init__.py
+++ b/src/htrun/host_tests_plugins/__init__.py
@@ -23,6 +23,7 @@ from . import module_reset_pyocd
 from . import module_copy_silabs
 from . import module_reset_silabs
 from . import module_copy_stlink
+from . import module_copy_stprogrammer
 from . import module_reset_stlink
 from . import module_copy_ublox
 from . import module_reset_ublox
@@ -49,6 +50,7 @@ HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_reset_mps2.load_plugin())
 HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_copy_silabs.load_plugin())
 HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_reset_silabs.load_plugin())
 HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_copy_stlink.load_plugin())
+HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_copy_stprogrammer.load_plugin())
 HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_reset_stlink.load_plugin())
 HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_power_cycle_target.load_plugin())
 HOST_TEST_PLUGIN_REGISTRY.register_plugin(module_reset_pyocd.load_plugin())

--- a/src/htrun/host_tests_plugins/module_copy_stprogrammer.py
+++ b/src/htrun/host_tests_plugins/module_copy_stprogrammer.py
@@ -1,0 +1,76 @@
+#
+# Copyright (c) 2021 Arm Limited and Contributors. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""Implements a plugin to flash ST devices using STM32CubeProgrammer.
+
+https://www.st.com/en/development-tools/stm32cubeprog.html
+"""
+
+import os
+from .host_test_plugins import HostTestPluginBase
+
+
+class HostTestPluginCopyMethod_STProgrammer(HostTestPluginBase):
+    """Plugin interface adaptor for STM32CubeProgrammer."""
+
+    # Plugin interface
+    name = "HostTestPluginCopyMethod_STProgrammer"
+    type = "CopyMethod"
+    capabilities = ["stprog"]
+    required_parameters = ["image_path"]
+
+    def __init__(self):
+        """Initialise the object."""
+        HostTestPluginBase.__init__(self)
+
+    def setup(self, *args, **kwargs):
+        """Configure plugin.
+
+        This function should be called before plugin execute() method is used.
+        """
+        self.CLI = "STM32_Programmer_CLI"
+        return True
+
+    def execute(self, capability, *args, **kwargs):
+        """Copy a firmware image to a device using STM32CubeProgrammer.
+
+        If the "capability" name is not 'stprog' this method will just fail.
+
+        Args:
+            capability: Capability name.
+            args: Additional arguments.
+            kwargs: Additional arguments.
+
+        Returns:
+            True if the copy succeeded, otherwise False.
+        """
+        from shutil import which
+
+        if which(self.CLI) is None:
+            print("%s is not part of environment PATH" % self.CLI)
+            return False
+
+        result = False
+        if self.check_parameters(capability, *args, **kwargs) is True:
+            image_path = os.path.normpath(kwargs["image_path"])
+            if capability == "stprog":
+                cmd = [
+                    self.CLI,
+                    "-c",
+                    "port=SWD",
+                    "mode=UR",
+                    "-w",
+                    image_path,
+                    "0x08000000",
+                    "-v",
+                    "-rst",
+                ]
+                result = self.run_command(cmd)
+        return result
+
+
+def load_plugin():
+    """Return plugin available in this module."""
+    return HostTestPluginCopyMethod_STProgrammer()


### PR DESCRIPTION
Hi

HTRUN has a plugin to use ST-LINK utility (`stlink`)

This tool is deprecated and replaced by STM32CubeProgrammer 
https://www.st.com/en/development-tools/stm32cubeprog.html

This pull request is adding first support of this new ST tool.

Tested OK with this command:
`htrun -f xxx.bin -d F: -p COM45:115200 -c stprog --sync=0 -P 30`
