### PR TITLE
Fix version option

### DIFF
--- a/src/htrun/htrun.py
+++ b/src/htrun/htrun.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2021-2022 Arm Limited and Contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 """Greentea Host Tests Runner."""
@@ -23,7 +23,7 @@ def main():
     if cli_params.version:  # --version
         import pkg_resources  # part of setuptools
 
-        version = pkg_resources.require("htrun")[0].version
+        version = pkg_resources.require("greentea-host")[0].version
         print(version)
     elif cli_params.send_break_cmd:  # -b with -p PORT (and optional -r RESET_TYPE)
         handle_send_break_cmd(


### PR DESCRIPTION
The version option was depending on the old package name for htrun,
instead of greentea-host, leading to errors like the following:

    Traceback (most recent call last):
      File "/home/user/greentea/.venv/bin/htrun", line 33, in <module>
        sys.exit(load_entry_point('greentea-host', 'console_scripts', 'htrun')())
      File "/home/user/greentea/src/htrun/htrun.py", line 26, in main
        version = pkg_resources.require("htrun")[0].version
      File "/home/user/greentea/.venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 900, in require
        needed = self.resolve(parse_requirements(requirements))
      File "/home/user/greentea/.venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 786, in resolve
        raise DistributionNotFound(req, requirers)
    pkg_resources.DistributionNotFound: The 'htrun' distribution was not found and is required by the application

Instead, depend on greentea-host to obtain version information. This
fixes the above error and enables the --version option to run again.